### PR TITLE
rimage: Add support for i.MX8X

### DIFF
--- a/src/file_simple.c
+++ b/src/file_simple.c
@@ -573,3 +573,26 @@ const struct adsp machine_imx8 = {
 	.machine_id = MACHINE_IMX8,
 	.write_firmware = simple_write_firmware,
 };
+
+const struct adsp machine_imx8x = {
+	.name = "imx8x",
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = IMX8_IRAM_BASE,
+			.size = IMX8_IRAM_SIZE,
+			.host_offset = IMX8_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = IMX8_DRAM_BASE,
+			.size = IMX8_DRAM_SIZE,
+			.host_offset = 0,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = IMX8_SRAM_BASE,
+			.size = IMX8_SRAM_SIZE,
+			.host_offset = 0,
+		},
+	},
+	.machine_id = MACHINE_IMX8X,
+	.write_firmware = simple_write_firmware,
+};

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -38,6 +38,7 @@ enum machine_id {
 	MACHINE_TIGERLAKE,
 	MACHINE_SUECREEK,
 	MACHINE_IMX8,
+	MACHINE_IMX8X,
 	MACHINE_MAX
 };
 
@@ -206,6 +207,6 @@ extern const struct adsp machine_sue;
 extern const struct adsp machine_skl;
 extern const struct adsp machine_kbl;
 extern const struct adsp machine_imx8;
-
+extern const struct adsp machine_imx8x;
 
 #endif

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -26,6 +26,7 @@ static const struct adsp *machine[] = {
 	&machine_kbl,
 	&machine_skl,
 	&machine_imx8,
+	&machine_imx8x,
 };
 
 static void usage(char *name)


### PR DESCRIPTION
i.MX8X is very similar with i.MX8. Memory layout is the same
except IRQSTEER address.

Code will be shared but there will be different firmware binaries
named:
	* sof-imx8.ri, for i.MX8
	* sof-imx8x.ri, for i.MX8X

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>