### PR TITLE
Fix compiler errors

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -466,7 +466,7 @@ int elf_validate_modules(struct image *image)
 
 int elf_find_section(const struct module *module, const char *name)
 {
-	Elf32_Ehdr *hdr = &module->hdr;
+	const Elf32_Ehdr *hdr = &module->hdr;
 	const Elf32_Shdr *section, *s;
 	char *buffer;
 	size_t count;


### PR DESCRIPTION
Fixes following error when compiling code:
...
src/elf.c: In function ‘elf_find_section’:
src/elf.c:469:20: error: initialization discards ‘const’ qualifier
           from pointer target type [-Werror=discarded-qualifiers]
  469 |  Elf32_Ehdr *hdr = &module->hdr;
      |                    ^
cc1: all warnings being treated as errors
...