### PR TITLE
Fix init_array section not copied to ri image

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -93,6 +93,8 @@ static int elf_read_sections(struct image *image, struct module *module,
 			module->bss_size += section[i].size;
 			module->num_bss++;
 			break;
+		case SHT_INIT_ARRAY:
+			/* fall through */
 		case SHT_PROGBITS:
 			/* text or data */
 			module->fw_size += section[i].size;
@@ -244,6 +246,8 @@ static void elf_module_size(struct image *image, struct module *module,
 			    Elf32_Shdr *section, int index)
 {
 	switch (section->type) {
+	case SHT_INIT_ARRAY:
+		/* fall through */
 	case SHT_PROGBITS:
 		/* text or data */
 		if (section->flags & SHF_EXECINSTR) {

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -128,7 +128,7 @@ static uint32_t elf_to_file_offset(struct image *image,
 {
 	uint32_t elf_addr = section->vaddr, file_offset = 0;
 
-	if (section->type == SHT_PROGBITS) {
+	if (section->type == SHT_PROGBITS || section->type == SHT_INIT_ARRAY) {
 		if (section->flags & SHF_EXECINSTR) {
 			/* text segment */
 			file_offset = elf_addr - module->text_start +
@@ -160,6 +160,8 @@ static int man_copy_sram(struct image *image, Elf32_Shdr *section,
 	size_t count;
 
 	switch (section->type) {
+	case SHT_INIT_ARRAY:
+		/* fall through */
 	case SHT_PROGBITS:
 		/* text or data */
 		if (section->flags & SHF_EXECINSTR)


### PR DESCRIPTION
Fixes Zephyr crashes in C++ tests with static constructors put in .init_array section.