### PR TITLE
Ext mnf optional

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -516,23 +516,14 @@ out:
 	return ret;
 }
 
-int elf_read_section(const struct image *image, const char *section_name,
+int elf_read_section(const struct module *module, const char *section_name,
 		     const Elf32_Shdr **dst_section, void **dst_buff)
 {
-	const struct module *module;
 	const Elf32_Shdr *section;
 	int section_index = -1;
 	int read;
-	int i;
 
-	/* when there is more than one module, then first one is bootloader */
-	for (i = image->num_modules == 1 ? 0 : 1; i < image->num_modules; i++) {
-		module = &image->module[i];
-		section_index = elf_find_section(module, section_name);
-		if (section_index >= 0)
-			break;
-	}
-
+	section_index = elf_find_section(module, section_name);
 	if (section_index < 0) {
 		fprintf(stderr, "error: section %s can't be found\n",
 			section_name);

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -76,12 +76,12 @@ static int ext_man_build(const struct image *image,
 	size_t offset;
 	int ret = 0;
 
-	ret = elf_read_section(image, ".fw_metadata", &section,
+	ret = elf_read_section(image, EXT_MAN_DATA_SECTION, &section,
 			       (void **)&sec_buffer);
 	if (ret < 0) {
 		fprintf(stderr,
-			"error: failed to read .fw_metadata section content, code %d\n",
-			ret);
+			"error: failed to read %s section content, code %d\n",
+			EXT_MAN_DATA_SECTION, ret);
 		goto out;
 	}
 

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -99,6 +99,7 @@ static int ext_man_build(const struct module *module,
 			EXT_MAN_DATA_SECTION, ret);
 		goto out;
 	}
+	ret = 0;
 
 	/* fill ext_man struct, size aligned to 4 to avoid unaligned accesses */
 	memcpy(&ext_man, &ext_man_template, sizeof(struct ext_man_header));

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -179,7 +179,7 @@ void elf_free_module(struct image *image, int module_index);
 int elf_is_rom(struct image *image, Elf32_Shdr *section);
 int elf_validate_modules(struct image *image);
 int elf_find_section(const struct module *module, const char *name);
-int elf_read_section(const struct image *image, const char *name,
+int elf_read_section(const struct module *module, const char *name,
 		     const Elf32_Shdr **dst_section, void **dst_buff);
 int elf_validate_section(struct image *image, struct module *module,
 			 Elf32_Shdr *section, int index);

--- a/src/include/sof/kernel/ext_manifest_gen.h
+++ b/src/include/sof/kernel/ext_manifest_gen.h
@@ -29,6 +29,8 @@
 
 #include "rimage.h"
 
+#define EXT_MAN_DATA_SECTION ".fw_metadata"
+
 int ext_man_write(struct image *image);
 
 #endif /* __EXT_MAN_H__ */

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -42,6 +42,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -x set xcc module offset\n");
 	fprintf(stdout, "\t -f firmware version = x.y\n");
 	fprintf(stdout, "\t -b build version\n");
+	fprintf(stdout, "\t -e build extended manifest\n");
 	exit(0);
 }
 
@@ -51,12 +52,13 @@ int main(int argc, char *argv[])
 	const char *mach = NULL;
 	int opt, ret, i, elf_argc = 0;
 	int imr_type = MAN_DEFAULT_IMR_TYPE;
+	int use_ext_man = 0;
 
 	memset(&image, 0, sizeof(image));
 
 	image.xcc_mod_offset = DEFAULT_XCC_MOD_OFFSET;
 
-	while ((opt = getopt(argc, argv, "ho:m:va:s:k:l:ri:x:f:b:")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:m:va:s:k:l:ri:x:f:b:e")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;
@@ -90,6 +92,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'b':
 			image.fw_ver_build_string = optarg;
+			break;
+		case 'e':
+			use_ext_man = 1;
 			break;
 		case 'h':
 			usage(argv[0]);
@@ -191,12 +196,14 @@ found:
 	if (ret)
 		goto out;
 
-	ret = ext_man_write(&image);
-	if (ret < 0) {
-		fprintf(stderr, "warning: unable to write extended manifest, %d\n",
-			ret);
-		/* ext man is optional until FW side merge to master */
-		ret = 0;
+	/* build extended manifest */
+	if (use_ext_man) {
+		ret = ext_man_write(&image);
+		if (ret < 0) {
+			fprintf(stderr, "error: unable to write extended manifest, %d\n",
+				ret);
+			goto out;
+		}
 	}
 
 out:


### PR DESCRIPTION
https://github.com/thesofproject/rimage/issues/12

Know logs for case when ext_mnf is not present loooks like:

```
warning: can't find section .fw_metadata in module /mnt/c/projects/sof_kt/build/sof-cnl
warning: unable to write extended manifest, -125
```

instead of:
```
warning: can't find section .fw_metadata in module /home/lrg/work/zephyrproject/zephyr/build/zephyr/zephyr.elf.mod
error: section .fw_metadata can't be found
error: failed to read .fw_metadata section content, code -22
warning: unable to write extended manifest, -22
```

For case with ext_man, there is no any difference in logs