### PR TITLE
ext_manifest: Add UUID dictionary

### DIFF
--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -128,6 +128,8 @@ static int ext_man_build(const struct module *module,
 	*dst_buff = (struct ext_man_header *)buffer;
 
 out:
+	if (!sec_buffer)
+		free(sec_buffer);
 	return ret;
 }
 

--- a/src/include/rimage/common.h
+++ b/src/include/rimage/common.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __RIMAGE_COMMON_H__
+#define __RIMAGE_COMMON_H__
+
+#ifndef ALIGN_UP
+#define ALIGN_UP(size, alignment) \
+	((size) + (((alignment) - ((size) % (alignment))) % (alignment)))
+#endif
+
+#ifndef max
+#define max(a,b) \
+   ({ __typeof__ (a) _a = (a); \
+       __typeof__ (b) _b = (b); \
+     _a > _b ? _a : _b; })
+#endif
+
+#ifndef min
+#define min(a,b) \
+   ({ __typeof__ (a) _a = (a); \
+       __typeof__ (b) _b = (b); \
+     _a < _b ? _a : _b; })
+#endif
+
+#endif /* __RIMAGE_COMMON_H__ */

--- a/src/include/sof/kernel/ext_manifest.h
+++ b/src/include/sof/kernel/ext_manifest.h
@@ -78,4 +78,11 @@ struct ext_man_elem_header {
 	/* just after this header should be type dependent content */
 } __packed;
 
+/* Extended manifest elements identificators */
+enum ext_man_elem_type {
+	EXT_MAN_ELEM_FW_VERSION		= 0,
+	EXT_MAN_ELEM_CC_VERSION		= 1,
+	EXT_MAN_ELEM_PROBE_INFO		= 2,
+};
+
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/sof/kernel/ext_manifest.h
+++ b/src/include/sof/kernel/ext_manifest.h
@@ -83,6 +83,7 @@ enum ext_man_elem_type {
 	EXT_MAN_ELEM_FW_VERSION		= 0,
 	EXT_MAN_ELEM_CC_VERSION		= 1,
 	EXT_MAN_ELEM_PROBE_INFO		= 2,
+	EXT_MAN_ELEM_UUID_DICT		= 3,
 };
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/sof/kernel/ext_manifest_gen.h
+++ b/src/include/sof/kernel/ext_manifest_gen.h
@@ -30,6 +30,7 @@
 #include "rimage.h"
 
 #define EXT_MAN_DATA_SECTION ".fw_metadata"
+#define EXT_MAN_UUID_DICT_SECTION ".fw_metadata_uuid_dict"
 
 int ext_man_write(struct image *image);
 


### PR DESCRIPTION
Such a dictionary will be used in kernel code to translate UUID value
to UUID dictionary key used in DSP in runtime.
Translation will be used for the process component creation and
runtime trace filtering.
Because there is no way to put right size to this extended element
header, list of uuid entries are located in separate section to
allow convenient size calculation from rimage level.
Extract common header with simple, generic preprocessor functions.

This PR is related with https://github.com/thesofproject/sof/pull/2914.