### PR TITLE
Default CMAKE_BUILD_TYPE to Debug, add assert() for NULL pointer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(SOF_RIMAGE C)
 
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No CMAKE_BUILD_TYPE, defaulting to Debug")
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build Type" FORCE)
+endif()
+
 add_executable(rimage
 	src/file_simple.c
 	src/man_apl.c
@@ -23,7 +28,7 @@ add_executable(rimage
 )
 
 target_compile_options(rimage PRIVATE
-	-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3
+	-Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3
 )
 
 target_link_libraries(rimage PRIVATE "-lcrypto")

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -2,6 +2,7 @@
 //
 // Copyright(c) 2015 Intel Corporation. All rights reserved.
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -189,10 +190,13 @@ found:
 	}
 
 	/* process and write output */
-	if (image.meu_offset)
+	if (image.meu_offset) {
+		assert(image.adsp->write_firmware_meu);
 		ret = image.adsp->write_firmware_meu(&image);
-	else
+	} else {
+		assert(image.adsp->write_firmware);
 		ret = image.adsp->write_firmware(&image);
+	}
 	if (ret)
 		goto out;
 


### PR DESCRIPTION
See commit messages.

This makes the write_firmware NULL pointer added by commit
dd77445 and corresponding crash more user-friendly.
Before:
```
  Program received signal SIGSEGV, Segmentation fault.
```
After:
```
  rimage: src/rimage.c:197: main: Assertion `image.adsp->write_firmware'
  failed.
```