### PR TITLE
manifest: set feature mask to 0xffff

### DIFF
--- a/src/include/rimage/sof/user/manifest.h
+++ b/src/include/rimage/sof/user/manifest.h
@@ -115,7 +115,7 @@ struct sof_man_mod_config {
 #define SOF_MAN_FW_HDR_ID		{'$', 'A', 'M', '1'}
 #define SOF_MAN_FW_HDR_NAME		"ADSPFW"
 #define SOF_MAN_FW_HDR_FLAGS		0x0
-#define SOF_MAN_FW_HDR_FEATURES		0x1ff
+#define SOF_MAN_FW_HDR_FEATURES		0xffff
 
 /*
  * The firmware has a standard header that is checked by the ROM on firmware


### PR DESCRIPTION
This feature is not used by SOF anyway and only causes
FW load failures, we can set it to 0xffff so it will
work for ADL+ platforms.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>