### PR TITLE
toml: Use only standard error codes

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -57,13 +57,13 @@ static int err_malloc(const char *key)
 /** log key not found error */
 static int err_key_not_found(const char *key)
 {
-	return log_err(-ENOKEY, "error: '%s' not found\n", key);
+	return log_err(-EINVAL, "error: '%s' not found\n", key);
 }
 
 /** error during parsing key value, possible detailed message */
 static int err_key_parse(const char *key, const char *extra_msg, ...)
 {
-	int ret = -EBADE;
+	int ret = -EINVAL;
 	va_list vl;
 
 	if (extra_msg) {


### PR DESCRIPTION
Error codes like ENOKEY and EBADE are not provide for all windows
toolchains, so to immit possible build errors, some more standard
error codes should be used.
Detailed error message is printed in stderr, so end user still
will be well informed about error source.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>