### PR TITLE
manifest.c: assert buffer overflow in man_copy_sram()

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -167,6 +167,8 @@ static int man_copy_sram(struct image *image, Elf32_Shdr *section,
 	void *buffer = image->fw_image + offset;
 	size_t count;
 
+	assert((uint64_t)offset + section->size <= image->adsp->image_size);
+
 	switch (section->type) {
 	case SHT_INIT_ARRAY:
 		/* fall through */


### PR DESCRIPTION
Does not solve https://github.com/thesofproject/sof/issues/3423 but
converts a buffer overflow and crash into a more usable assert.

Buffer overflow found by running rimage with valgrind and the binaries
provided by @singalsu

Signed-off-by: Marc Herbert <marc.herbert@intel.com>