### PR TITLE
gitignore: Add checkpatch temporary file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.checkpatch-camelcase.git.*


### PR DESCRIPTION
Any generated file should be tracked by git to keep repositiry clean.
Such an file should be added to .gitignore to reduce possibility of
accidentally pushig this file to remote branches, eg. after typing
`git add *` before pushing changes.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>