### PR TITLE
rimage signing support for CAVS2.5

### DIFF
--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -22,15 +22,15 @@ size = "0x100000"
 partition_name = "ADSP"
 [[cse.entry]]
 name = "ADSP.man"
-offset = "0x58"
-length = "0x378"
+offset = "0x5c"
+length = "0x464"
 [[cse.entry]]
 name = "cavs0015.met"
-offset = "0x400"
+offset = "0x4c0"
 length = "0x70"
 [[cse.entry]]
 name = "cavs0015"
-offset = "0x490"
+offset = "0x540"
 length = "0x0"  # calculated by rimage
 
 [css]
@@ -38,11 +38,6 @@ length = "0x0"  # calculated by rimage
 [signed_pkg]
 name = "ADSP"
 [[signed_pkg.module]]
-name = "cavs0015.met"
-
-[partition_info]
-name = "ADSP"
-[[partition_info.module]]
 name = "cavs0015.met"
 
 [adsp_file]

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -1755,6 +1755,7 @@ static int parse_adsp_config_v1_5(const toml_table_t *toml, struct adsp *out,
 		/* assign correct write functions */
 		out->write_firmware = man_write_fw_v1_5_sue;
 		out->write_firmware_meu = man_write_fw_meu_v1_5;
+		out->verify_firmware = ri_manifest_verify_v1_5;
 
 		/* parse others sibtables */
 		ret = parse_fw_desc(toml, &ctx, &out->man_v1_5_sue->desc, verbose);
@@ -1772,6 +1773,7 @@ static int parse_adsp_config_v1_5(const toml_table_t *toml, struct adsp *out,
 		/* assign correct write functions */
 		out->write_firmware = man_write_fw_v1_5;
 		out->write_firmware_meu = man_write_fw_meu_v1_5;
+		out->verify_firmware = ri_manifest_verify_v1_5;
 
 		/* parse others sibtables */
 		ret = parse_css_v1_5(toml, &ctx, &out->man_v1_5->css_header, verbose);
@@ -1808,6 +1810,7 @@ static int parse_adsp_config_v1_8(const toml_table_t *toml, struct adsp *out,
 	/* assign correct write functions */
 	out->write_firmware = man_write_fw_v1_8;
 	out->write_firmware_meu = man_write_fw_meu_v1_8;
+	out->verify_firmware = ri_manifest_verify_v1_8;
 
 	/* version array has already been parsed, so increment ctx.array_cnt */
 	parse_ctx_init(&ctx);
@@ -1868,6 +1871,7 @@ static int parse_adsp_config_v2_5(const toml_table_t *toml, struct adsp *out,
 	/* assign correct write functions */
 	out->write_firmware = man_write_fw_v2_5;
 	out->write_firmware_meu = man_write_fw_meu_v2_5;
+	out->verify_firmware = ri_manifest_verify_v2_5;
 
 	/* version array has already been parsed, so increment ctx.array_cnt */
 	parse_ctx_init(&ctx);

--- a/src/cse.c
+++ b/src/cse.c
@@ -6,6 +6,7 @@
 //         Keyon Jie <yang.jie@linux.intel.com>
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <rimage/rimage.h>
 #include <rimage/cse.h>
 #include <rimage/manifest.h>
@@ -33,4 +34,75 @@ void ri_cse_create(struct image *image)
 		csum += val[i];
 	}
 	cse_hdr->checksum = 0x100 - csum;
+}
+
+static uint32_t crc32(uint8_t *input, int size, uint32_t poly, uint32_t init,
+		      bool rev_in, bool rev_out, uint32_t xor_out)
+{
+	uint32_t crc = init;
+	uint32_t t32;
+	uint8_t val;
+	uint8_t t8;
+	int i;
+	int j;
+
+	for (i = 0; i < size; i++) {
+		val = input[i];
+		if (rev_in) {
+			t8 = 0;
+			for (j = 0; j < 8; j++) {
+				if (val & (1 << j))
+					t8 |= (uint8_t)(1 << (7 - j));
+			}
+			val = t8;
+		}
+		crc ^= (uint32_t)(val << 24);
+		for (j = 0; j < 8; j++) {
+			if (crc & 0x80000000)
+				crc = (uint32_t)((crc << 1) ^ poly);
+			else
+				crc <<= 1;
+		}
+	}
+
+	if (rev_out) {
+		t32 = 0;
+		for (i = 0; i < 32; i++) {
+			if (crc & (1 << i))
+				t32 |= (uint32_t)(1 << (31 - i));
+		}
+		crc = t32;
+	}
+
+	return crc ^ xor_out;
+}
+
+void ri_cse_create_v2_5(struct image *image)
+{
+	struct CsePartitionDirHeader_v2_5 *cse_hdr = image->fw_image;
+	struct sof_man_adsp_meta_file_ext_v2_5 *meta = image->fw_image +
+		MAN_META_EXT_OFFSET_V2_5;
+	struct CsePartitionDirEntry *cse_entry =
+		image->fw_image + sizeof(*cse_hdr);
+	uint8_t *val = image->fw_image;
+	int size;
+
+	fprintf(stdout, " cse: completing CSE V2.5 manifest\n");
+
+	cse_entry[2].length = meta->comp_desc[0].limit_offset -
+		MAN_DESC_OFFSET_V1_8;
+
+	/*
+	 * calculate checksum using crc-32/iso-hdlc
+	 *
+	 * polynomial: 0x04c11db7
+	 * initial value: 0xffffffff
+	 * reverse input: true
+	 * reverse output: true
+	 * xor output: 0xffffffff
+	 */
+	size = (sizeof(*cse_hdr) + (sizeof(*cse_entry) * MAN_CSE_PARTS));
+	cse_hdr->checksum = crc32(val, size, 0x04c11db7, 0xffffffff, true, true, 0xffffffff);
+
+	fprintf(stdout, " cse: cse checksum %x\n", cse_hdr->checksum);
 }

--- a/src/css.c
+++ b/src/css.c
@@ -11,6 +11,63 @@
 #include <rimage/css.h>
 #include <rimage/manifest.h>
 
+void ri_css_v2_5_hdr_create(struct image *image)
+{
+	struct css_header_v2_5 *css = image->fw_image + MAN_CSS_HDR_OFFSET_2_5;
+	struct tm *date;
+	struct timeval tv;
+	time_t seconds;
+	int val;
+
+	fprintf(stdout, " cse: completing CSS manifest\n");
+
+	/* get local time and date */
+	gettimeofday(&tv, NULL);
+	seconds = tv.tv_sec;
+	date = localtime(&seconds);
+
+	if (!date) {
+		fprintf(stderr, "error: cant get localtime %d\n", -errno);
+		return;
+	}
+
+	date->tm_year += 1900;
+	fprintf(stdout, " css: set build date to %d:%2.2d:%2.2d\n",
+		date->tm_year, date->tm_mon, date->tm_mday);
+
+	/* year yYyy */
+	val = date->tm_year / 1000;
+	css->date |= val  << 28;
+	date->tm_year -= val * 1000;
+	/* year yyYy */
+	val = date->tm_year / 100;
+	css->date |= val << 24;
+	date->tm_year -= val * 100;
+	/* year yyyY */
+	val = date->tm_year / 10;
+	css->date |= val << 20;
+	date->tm_year -= val * 10;
+	/* year Yyyy */
+	val = date->tm_year;
+	css->date |= val << 16;
+
+	/* month Mm - for some reason month starts at 0 */
+	val = ++date->tm_mon / 10;
+	css->date |= val << 12;
+	date->tm_mon -= (val * 10);
+	/* month mM */
+	val = date->tm_mon;
+	css->date |= val << 8;
+
+	/* Day Dd */
+	val = date->tm_mday / 10;
+	css->date |= val << 4;
+	date->tm_mday -= (val * 10);
+	/* Day dD */
+	val = date->tm_mday;
+	css->date |= val << 0;
+}
+
 void ri_css_v1_8_hdr_create(struct image *image)
 {
 	struct css_header_v1_8 *css = image->fw_image + MAN_CSS_HDR_OFFSET;

--- a/src/hash.c
+++ b/src/hash.c
@@ -89,7 +89,7 @@ void ri_sha256(struct image *image, unsigned int offset, unsigned int size,
 	module_sha_complete(image, hash);
 }
 
-static void module_sha384_create(struct image *image)
+void module_sha384_create(struct image *image)
 {
 	image->md = EVP_sha384();
 	image->mdctx = EVP_MD_CTX_new();

--- a/src/include/rimage/cse.h
+++ b/src/include/rimage/cse.h
@@ -22,6 +22,17 @@ struct CsePartitionDirHeader {
 	uint8_t  partition_name[4];
 }  __attribute__((packed));
 
+struct CsePartitionDirHeader_v2_5 {
+	uint32_t header_marker;
+	uint32_t nb_entries;
+	uint8_t  header_version;
+	uint8_t  entry_version;
+	uint8_t  header_length;
+	uint8_t  not_used; /* set to zero - old checksum */
+	uint8_t  partition_name[4];
+	uint32_t checksum; /* crc32 checksum */
+}  __attribute__((packed));
+
 struct CsePartitionDirEntry {
 	uint8_t  entry_name[12];
 	uint32_t offset;
@@ -30,5 +41,6 @@ struct CsePartitionDirEntry {
 }  __attribute__((packed));
 
 void ri_cse_create(struct image *image);
+void ri_cse_create_v2_5(struct image *image);
 
 #endif

--- a/src/include/rimage/css.h
+++ b/src/include/rimage/css.h
@@ -13,12 +13,15 @@ struct image;
 #define MAN_CSS_LT_MODULE_TYPE		0x00000006
 #define MAN_CSS_MOD_TYPE		4
 #define MAN_CSS_HDR_SIZE		161	/* in words */
+#define MAN_CSS_HDR_SIZE_2_5		225	/* in words */
 #define MAN_CSS_HDR_VERSION		0x10000
+#define MAN_CSS_HDR_VERSION_2_5		0x21000
 #define MAN_CSS_MOD_VENDOR		0x8086
 #define MAN_CSS_HDR_ID			{'$', 'M', 'N', '2'}
 
 #define MAN_CSS_KEY_SIZE		(MAN_RSA_KEY_MODULUS_LEN >> 2)
 #define MAN_CSS_MOD_SIZE		(MAN_RSA_KEY_MODULUS_LEN >> 2)
+#define MAN_CSS_MOD_SIZE_2_5		(MAN_RSA_KEY_MODULUS_LEN_2_5 >> 2)
 #define MAN_CSS_EXP_SIZE		(MAN_RSA_KEY_EXPONENT_LEN >> 2)
 #define MAN_CSS_MAN_SIZE_V1_8		\
 	(sizeof(struct fw_image_manifest_v1_8) >> 2)
@@ -29,14 +32,36 @@ struct image;
  * RSA Key and Crypto
  */
 #define MAN_RSA_KEY_MODULUS_LEN		256
+#define MAN_RSA_KEY_MODULUS_LEN_2_5	384
 #define MAN_RSA_KEY_EXPONENT_LEN	4
 #define MAN_RSA_SIGNATURE_LEN		256
+#define MAN_RSA_SIGNATURE_LEN_2_5	384
 
 struct fw_version {
 	uint16_t major_version;
 	uint16_t minor_version;
 	uint16_t hotfix_version;
 	uint16_t build_version;
+} __attribute__((packed));
+
+struct css_header_v2_5 {
+	uint32_t header_type;
+	uint32_t header_len;
+	uint32_t header_version;
+	uint32_t reserved0; /* must be 0x1 */
+	uint32_t module_vendor;
+	uint32_t date;
+	uint32_t size;
+	uint8_t header_id[4];
+	uint32_t padding;  /* must be 0x0 */
+	struct fw_version version;
+	uint32_t svn;
+	uint32_t reserved1[18];  /* must be 0x0 */
+	uint32_t modulus_size;
+	uint32_t exponent_size;
+	uint8_t modulus[MAN_RSA_KEY_MODULUS_LEN_2_5];
+	uint8_t exponent[MAN_RSA_KEY_EXPONENT_LEN];
+	uint8_t signature[MAN_RSA_SIGNATURE_LEN_2_5];
 } __attribute__((packed));
 
 struct css_header_v1_8 {
@@ -78,5 +103,6 @@ struct css_header_v1_5 {
 
 void ri_css_v1_8_hdr_create(struct image *image);
 void ri_css_v1_5_hdr_create(struct image *image);
+void ri_css_v2_5_hdr_create(struct image *image);
 
 #endif

--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -179,6 +179,7 @@ int simple_write_firmware(struct image *image);
 int man_write_fw_v1_5(struct image *image);
 int man_write_fw_v1_5_sue(struct image *image);
 int man_write_fw_v1_8(struct image *image);
+int man_write_fw_v2_5(struct image *image);
 int man_write_fw_meu_v1_5(struct image *image);
 int man_write_fw_meu_v1_8(struct image *image);
 int man_write_fw_meu_v2_5(struct image *image);

--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -41,8 +41,13 @@
 	sizeof(struct CsePartitionDirHeader) + \
 	MAN_CSE_PARTS * sizeof(struct CsePartitionDirEntry))
 
+#define MAN_CSS_HDR_OFFSET_2_5 \
+	(MAN_CSE_HDR_OFFSET + \
+	sizeof(struct CsePartitionDirHeader_v2_5) + \
+	MAN_CSE_PARTS * sizeof(struct CsePartitionDirEntry))
+
 #define MAN_FW_DESC_OFFSET_V2_5 \
-	(MAN_META_EXT_OFFSET_V1_8 + \
+	(MAN_META_EXT_OFFSET_V2_5 + \
 	sizeof(struct sof_man_adsp_meta_file_ext_v2_5) + \
 	MAN_EXT_PADDING)
 
@@ -53,15 +58,29 @@
 	(MAN_CSS_HDR_OFFSET + \
 	sizeof(struct css_header_v1_8))
 
+#define MAN_SIG_PKG_OFFSET_V2_5 \
+	(MAN_CSS_HDR_OFFSET_2_5 + \
+	sizeof(struct css_header_v2_5))
+
 #define MAN_PART_INFO_OFFSET_V1_8 \
 	(MAN_SIG_PKG_OFFSET_V1_8 + \
 	sizeof(struct signed_pkg_info_ext))
+
+#define MAN_PART_INFO_OFFSET_V2_5 \
+	(MAN_SIG_PKG_OFFSET_V2_5 + \
+	sizeof(struct signed_pkg_info_ext_v2_5))
 
 #define MAN_META_EXT_OFFSET_V1_8 \
 	(MAN_SIG_PKG_OFFSET_V1_8 + \
 	sizeof(struct signed_pkg_info_ext) + \
 	sizeof(struct partition_info_ext) + \
 	MAN_CSE_PADDING_SIZE)
+
+#define MAN_META_EXT_OFFSET_V2_5 \
+	(MAN_SIG_PKG_OFFSET_V2_5 + \
+	sizeof(struct signed_pkg_info_ext_v2_5) + \
+	sizeof(struct info_ext_0x16) + \
+	0)
 
 #define MAN_FW_DESC_OFFSET_V1_8 \
 	(MAN_META_EXT_OFFSET_V1_8 + \
@@ -91,12 +110,12 @@
  */
 struct fw_image_manifest_v2_5 {
 	/* MEU tool needs these sections to be 0s */
-	struct CsePartitionDirHeader cse_partition_dir_header;
+	struct CsePartitionDirHeader_v2_5 cse_partition_dir_header;
 	struct CsePartitionDirEntry cse_partition_dir_entry[MAN_CSE_PARTS];
-	struct css_header_v1_8 css;
-	struct signed_pkg_info_ext signed_pkg;
-	struct partition_info_ext partition_info;
-	uint8_t cse_padding[MAN_CSE_PADDING_SIZE];
+	struct css_header_v2_5 css;
+	struct signed_pkg_info_ext_v2_5 signed_pkg;
+	struct info_ext_0x16 info_0x16;
+
 	struct sof_man_adsp_meta_file_ext_v2_5 adsp_file_ext;
 
 	/* reserved / pading at end of ext data - all 0s*/

--- a/src/include/rimage/plat_auth.h
+++ b/src/include/rimage/plat_auth.h
@@ -11,6 +11,7 @@
 struct image;
 
 #define PLAT_AUTH_SHA256_LEN		32
+#define PLAT_AUTH_SHA384_LEN		48
 #define PLAT_AUTH_NAME_LEN		12
 #define PLAT_AUTH_PADDING		48	/* pad at end of struct */
 
@@ -24,6 +25,15 @@ struct signed_pkg_info_module {
 	uint16_t hash_size;
 	uint32_t meta_size;
 	uint8_t hash[PLAT_AUTH_SHA256_LEN];
+} __attribute__((packed));
+
+struct signed_pkg_info_module_v2_5 {
+	uint8_t name[PLAT_AUTH_NAME_LEN]; /* must be padded with 0 */
+	uint8_t type;
+	uint8_t hash_algo;
+	uint16_t hash_size;
+	uint32_t meta_size;
+	uint8_t hash[PLAT_AUTH_SHA384_LEN];
 } __attribute__((packed));
 
 struct signed_pkg_info_ext {
@@ -40,6 +50,22 @@ struct signed_pkg_info_ext {
 
 	/* variable length of modules */
 	struct signed_pkg_info_module module[SIGN_PKG_NUM_MODULE];
+} __attribute__((packed));
+
+struct signed_pkg_info_ext_v2_5 {
+	uint32_t ext_type;
+	uint32_t ext_len;
+
+	uint8_t name[4];
+	uint32_t vcn; /* 0 */
+	uint8_t bitmap[16];
+	uint32_t svn;
+	uint8_t fw_type;
+	uint8_t fw_sub_type;
+	uint8_t reserved[14];	/* must be 0 */
+
+	/* variable length of modules */
+	struct signed_pkg_info_module_v2_5 module[SIGN_PKG_NUM_MODULE];
 } __attribute__((packed));
 
 
@@ -73,6 +99,17 @@ struct partition_info_ext {
 	struct partition_info_module module[PART_INFO_NUM_MODULE];
 } __attribute__((packed));
 
+/* offset 0x458 id */
+struct info_ext_0x16 {
+	uint32_t ext_type;	/* 0x16 */
+	uint32_t ext_len;	/* 0x68 */
+	uint8_t name[4];	/* ADSP */
+	uint32_t size;		/* file size */
+	uint32_t data[5];	/* 0 = 0x10000000, 0, 1, 1, 0x3003 */
+	uint8_t hash[PLAT_AUTH_SHA384_LEN];
+	uint32_t data1[5];
+} __attribute__((packed));
+
 
 #define PLAT_AUTH_SIZE \
 	(sizeof(struct partition_info_ext) + \
@@ -83,5 +120,6 @@ void ri_adsp_meta_data_create_v1_8(struct image *image, int meta_start_offset,
 void ri_adsp_meta_data_create_v2_5(struct image *image, int meta_start_offset,
 				   int meta_end_offset);
 void ri_plat_ext_data_create(struct image *image);
+void ri_plat_ext_data_create_v2_5(struct image *image);
 
 #endif

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -157,6 +157,7 @@ struct adsp {
 };
 
 void module_sha256_create(struct image *image);
+void module_sha384_create(struct image *image);
 void module_sha_update(struct image *image, uint8_t *data, size_t bytes);
 void module_sha_complete(struct image *image, uint8_t *hash);
 int ri_manifest_sign_v1_5(struct image *image);

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -162,6 +162,7 @@ void module_sha_update(struct image *image, uint8_t *data, size_t bytes);
 void module_sha_complete(struct image *image, uint8_t *hash);
 int ri_manifest_sign_v1_5(struct image *image);
 int ri_manifest_sign_v1_8(struct image *image);
+int ri_manifest_sign_v2_5(struct image *image);
 void ri_sha256(struct image *image, unsigned int offset, unsigned int size,
 	       uint8_t *hash);
 void ri_sha384(struct image *image, unsigned int offset, unsigned int size,

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -173,6 +173,10 @@ int pkcs_v1_5_sign_man_v1_8(struct image *image,
 			    struct fw_image_manifest_v1_8 *man,
 			    void *ptr1, unsigned int size1, void *ptr2,
 			    unsigned int size2);
+int pkcs_v1_5_sign_man_v2_5(struct image *image,
+			    struct fw_image_manifest_v2_5 *man,
+			    void *ptr1, unsigned int size1, void *ptr2,
+			    unsigned int size2);
 
 int elf_parse_module(struct image *image, int module_index, const char *name);
 void elf_free_module(struct image *image, int module_index);

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -104,6 +104,7 @@ struct image {
 	uint32_t image_end;/* module end, equal to output image size */
 	int meu_offset;
 	int xcc_mod_offset;
+	const char *verify_file;
 
 	/* SHA 256 & 384 */
 	const char *key_name;
@@ -149,6 +150,7 @@ struct adsp {
 	enum machine_id machine_id;
 	int (*write_firmware)(struct image *image);
 	int (*write_firmware_meu)(struct image *image);
+	int (*verify_firmware)(struct image *image);
 	struct fw_image_manifest_v2_5 *man_v2_5;
 	struct fw_image_manifest_v1_8 *man_v1_8;
 	struct fw_image_manifest_v1_5 *man_v1_5;
@@ -176,6 +178,22 @@ int pkcs_v1_5_sign_man_v1_8(struct image *image,
 			    void *ptr1, unsigned int size1, void *ptr2,
 			    unsigned int size2);
 int pkcs_v1_5_sign_man_v2_5(struct image *image,
+			    struct fw_image_manifest_v2_5 *man,
+			    void *ptr1, unsigned int size1, void *ptr2,
+			    unsigned int size2);
+
+int verify_image(struct image *image);
+int ri_manifest_verify_v1_5(struct image *image);
+int ri_manifest_verify_v1_8(struct image *image);
+int ri_manifest_verify_v2_5(struct image *image);
+int pkcs_v1_5_verify_man_v1_5(struct image *image,
+			    struct fw_image_manifest_v1_5 *man,
+			    void *ptr1, unsigned int size1);
+int pkcs_v1_5_verify_man_v1_8(struct image *image,
+			    struct fw_image_manifest_v1_8 *man,
+			    void *ptr1, unsigned int size1, void *ptr2,
+			    unsigned int size2);
+int pkcs_v1_5_verify_man_v2_5(struct image *image,
 			    struct fw_image_manifest_v2_5 *man,
 			    void *ptr1, unsigned int size1, void *ptr2,
 			    unsigned int size2);

--- a/src/include/rimage/sof/user/manifest.h
+++ b/src/include/rimage/sof/user/manifest.h
@@ -73,6 +73,7 @@ struct sof_man_segment_desc {
 #define SOF_MAN_MOD_ID_LEN		4
 #define SOF_MAN_MOD_NAME_LEN		8
 #define SOF_MAN_MOD_SHA256_LEN		32
+#define SOF_MAN_MOD_SHA384_LEN		48
 #define SOF_MAN_MOD_ID			{'$', 'A', 'M', 'E'}
 
 /*

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1291,6 +1291,21 @@ int man_write_fw_v2_5(struct image *image)
 	if (ret < 0)
 		goto err;
 
+#if 0
+	/* calculate hash - SHA384 on CAVS2_5+ */
+	module_sha384_create(image);
+	module_sha_update(image, image->fw_image,
+			sizeof(struct CsePartitionDirHeader_v2_5) +
+			sizeof(struct CsePartitionDirEntry) * 3);
+	module_sha_update(image, image->fw_image + 0x4c0, image->image_end - 0x4c0);
+	module_sha_complete(image, hash);
+
+	/* hash values in reverse order */
+	for (i = 0; i < SOF_MAN_MOD_SHA384_LEN; i++) {
+		m->info_0x16.hash[i] =
+			hash[SOF_MAN_MOD_SHA384_LEN - 1 - i];
+	}
+#endif
 	/* write the firmware */
 	ret = man_write_fw_mod(image);
 	if (ret < 0)

--- a/src/pkcs1_5.c
+++ b/src/pkcs1_5.c
@@ -240,6 +240,109 @@ int pkcs_v1_5_sign_man_v1_8(struct image *image,
 	return ret;
 }
 
+/*
+ * RSA signature of manifest. The signature is an RSA PSS
+ * of the entire manifest structure, including all
+ * extensions, and excluding the last 3 fields of the
+ * manifest header (Public Key, Exponent and Signature).
+ */
+
+int pkcs_v1_5_sign_man_v2_5(struct image *image,
+			    struct fw_image_manifest_v2_5 *man,
+			    void *ptr1, unsigned int size1, void *ptr2,
+			    unsigned int size2)
+{
+	RSA *priv_rsa = NULL;
+	EVP_PKEY *privkey;
+	FILE *fp;
+	const BIGNUM *n, *e, *d;
+	unsigned char digest[SHA384_DIGEST_LENGTH];
+	unsigned char mod[MAN_RSA_KEY_MODULUS_LEN_2_5];
+	unsigned char sig[MAN_RSA_SIGNATURE_LEN_2_5];
+	char path[256];
+	int ret = -EINVAL, i;
+
+#if DEBUG_PKCS
+	fprintf(stdout, "offsets 0x%lx size 0x%x offset 0x%lx size 0x%x\n",
+		ptr1 - (void *)man, size1, ptr2 - (void *)man, size2);
+#endif
+
+	/* require private key */
+	if (!image->key_name) {
+		return -EINVAL;
+	}
+
+	/* create new PSS key */
+	privkey = EVP_PKEY_new();
+	if (!privkey)
+		return -ENOMEM;
+
+	/* load in RSA private key from PEM file */
+	memset(path, 0, sizeof(path));
+	strncpy(path, image->key_name, sizeof(path) - 1);
+
+	fprintf(stdout, " pkcs: PSS signing with key %s\n", path);
+	fp = fopen(path, "rb");
+	if (!fp) {
+		fprintf(stderr, "error: can't open file %s %d\n",
+			path, -errno);
+		return -errno;
+	}
+	PEM_read_PrivateKey(fp, &privkey, NULL, NULL);
+	fclose(fp);
+
+	/* validate RSA private key */
+	priv_rsa = EVP_PKEY_get1_RSA(privkey);
+	if (RSA_check_key(priv_rsa)) {
+		fprintf(stdout, " pkcs: RSA private key is valid.\n");
+	} else {
+		fprintf(stderr, "error: validating RSA private key.\n");
+		return -EINVAL;
+	}
+
+	/* calculate the digest - SHA384 on CAVS2_5+ */
+	module_sha384_create(image);
+	module_sha_update(image, ptr1, size1);
+	module_sha_update(image, ptr2, size2);
+	module_sha_complete(image, digest);
+
+	fprintf(stdout, " pkcs: digest for manifest is ");
+	for (i = 0; i < SHA384_DIGEST_LENGTH; i++)
+		fprintf(stdout, "%02x", digest[i]);
+	fprintf(stdout, "\n");
+
+	/* sign the manifest */
+	ret = RSA_padding_add_PKCS1_PSS(priv_rsa, sig,
+			digest, image->md, 32);
+	if (ret <= 0) {
+		ERR_error_string(ERR_get_error(), path);
+		fprintf(stderr, "error: failed to sign manifest %s\n", path);
+	}
+
+	/* encrypt the signature using the private key */
+	ret = RSA_private_encrypt(RSA_size(priv_rsa), sig,
+		     (unsigned char *)man->css.signature, priv_rsa, RSA_NO_PADDING);
+	if (ret <= 0) {
+		ERR_error_string(ERR_get_error(), path);
+		fprintf(stderr, "error: failed to encrypt signature %s\n", path);
+	}
+
+	/* copy public key modulus and exponent to manifest */
+	RSA_get0_key(priv_rsa, &n, &e, &d);
+	BN_bn2bin(n, mod);
+	BN_bn2bin(e, (unsigned char *)man->css.exponent);
+
+	/* modulus is reversed  */
+	for (i = 0; i < MAN_RSA_KEY_MODULUS_LEN_2_5; i++)
+		man->css.modulus[i] = mod[MAN_RSA_KEY_MODULUS_LEN_2_5 - (1 + i)];
+
+	/* signature is reversed, swap it */
+	bytes_swap(man->css.signature, sizeof(man->css.signature));
+
+	EVP_PKEY_free(privkey);
+	return ret;
+}
+
 int ri_manifest_sign_v1_5(struct image *image)
 {
 	struct fw_image_manifest_v1_5 *man = image->fw_image;
@@ -265,4 +368,21 @@ int ri_manifest_sign_v1_8(struct image *image)
 		(man->css.size - man->css.header_len) * sizeof(uint32_t);
 
 	return pkcs_v1_5_sign_man_v1_8(image, man, data1, size1, data2, size2);
+}
+
+int ri_manifest_sign_v2_5(struct image *image)
+{
+	struct fw_image_manifest_v2_5 *man = image->fw_image;
+
+	char *const data1 = (char *)man + MAN_CSS_HDR_OFFSET_2_5;
+	unsigned const size1 =
+		sizeof(struct css_header_v2_5) -
+		(MAN_RSA_KEY_MODULUS_LEN_2_5 + MAN_RSA_KEY_EXPONENT_LEN +
+		 MAN_RSA_SIGNATURE_LEN_2_5);
+
+	char *const data2 = (char *)man + MAN_SIG_PKG_OFFSET_V2_5;
+	unsigned const size2 =
+			(man->css.size - man->css.header_len) * sizeof(uint32_t);
+
+	return pkcs_v1_5_sign_man_v2_5(image, man, data1, size1, data2, size2);
 }

--- a/src/plat_auth.c
+++ b/src/plat_auth.c
@@ -57,3 +57,21 @@ void ri_plat_ext_data_create(struct image *image)
 	/* do this here atm */
 	desc->header.preload_page_count = part->length / MAN_PAGE_SIZE;
 }
+
+void ri_plat_ext_data_create_v2_5(struct image *image)
+{
+	struct sof_man_adsp_meta_file_ext_v2_5 *meta =
+		image->fw_image + MAN_META_EXT_OFFSET_V2_5;
+	struct sof_man_fw_desc *desc = image->fw_image + MAN_DESC_OFFSET_V1_8;
+	struct info_ext_0x16 *ext = image->fw_image + MAN_PART_INFO_OFFSET_V2_5;
+	uint32_t size;
+
+	fprintf(stdout, " auth: completing authentication manifest\n");
+
+	size = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_8;
+	size += MAN_PAGE_SIZE - (size % MAN_PAGE_SIZE);
+
+	/* do this here atm */
+	desc->header.preload_page_count = size / MAN_PAGE_SIZE;
+	ext->size = image->image_end;
+}


### PR DESCRIPTION
This PR will add signing support for CAVS2.5 platforms. Key differences are hashes are now SHA384 and signing is now RSA PSS. This is a plan B until meu can be released.

TODO:

- [x] CSE checksum is 32bits instead of 8bits and needs fixed. Unsure of checksum end address (i.e. scope of data that is checksummed).
- [x] Hashes start/end and sizes for ext0x16 and ext signed_pkg
- [x] Validation support to be added to rimage - this allows the tool to self validate and to validate meu (as a means to confirming CAVS2.5 signing is correct as PSS signatures are not reproducible)