### PR TITLE
README: install is optional and missed "sudo". CMake 3.13 -B option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ to generate binary image files.
 
 ## Building
 
-The `rimage` tool can be built with the following commands:
+The `rimage` tool can be built with the usual CMake commands:
 
 ```shell
-$ mkdir build
-$ cd build
-$ cmake ..
-$ make
-$ make install
+$ cmake -B build/
+$ make  -C build/ help # lists all targets
+$ make  -C build/
+$ sudo make -C build/ install # optional
 ```


### PR DESCRIPTION
Also show useful "make help" that lists all targets.

Show -B option of CMake that avoids changing the current directory to
the build directory: especially inconvenient considering the
recommended, CMake way to clean is to delete this directory and the
recommended way to build multiple configurations is to use multiple
build directories.

-B was introduced in CMake 3.13 which has been released two years ago
now and CMake spoils its users with a choice of ways to upgrade:

https://cmake.org/download/
 https://apt.kitware.com/
 https://pypi.org/project/cmake/

This does _not_ imply CMakeLists.txt should drop backward compatibility
with CMake < 3.13. I only think a README.md file should not keep the
majority of users in the dark only for the convenience of a minority of
obsolete CMake users.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>