### PR TITLE
pkcs_v1_5_sign_man_v2_5(): add "salt length" comment

### DIFF
--- a/src/pkcs1_5.c
+++ b/src/pkcs1_5.c
@@ -313,7 +313,7 @@ int pkcs_v1_5_sign_man_v2_5(struct image *image,
 
 	/* sign the manifest */
 	ret = RSA_padding_add_PKCS1_PSS(priv_rsa, sig,
-			digest, image->md, 32);
+			digest, image->md, /* salt length */ 32);
 	if (ret <= 0) {
 		ERR_error_string(ERR_get_error(), path);
 		fprintf(stderr, "error: failed to sign manifest %s\n", path);


### PR DESCRIPTION
This comment is meant for "git grep salt", that's its main purpose.

Much more obvious timestamps aside, this new code is the only
non-deterministic part of rimage - learned the very hard way
(OpenSSL "documentation" calls it "sLen"...)

A/B testing of build system changes is much, much easier when
locally and temporarily making the build 100% deterministic.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>