### PR TITLE
minor -h fix: -s meu_offset disables rimage signing

### DIFF
--- a/src/rimage.c
+++ b/src/rimage.c
@@ -24,7 +24,7 @@ static void usage(char *name)
 			name);
 	fprintf(stdout, "\t -v enable verbose output\n");
 	fprintf(stdout, "\t -r enable relocatable ELF files\n");
-	fprintf(stdout, "\t -s MEU signing offset\n");
+	fprintf(stdout, "\t -s MEU signing offset, disables rimage signing\n");
 	fprintf(stdout, "\t -i set IMR type\n");
 	fprintf(stdout, "\t -x set xcc module offset\n");
 	fprintf(stdout, "\t -f firmware version = x.y\n");


### PR DESCRIPTION
It wasn't exactly obvious who does what.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>