### PR TITLE
rimage: add support to strip signature in signed fw

### DIFF
--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -105,6 +105,7 @@ struct image {
 	int meu_offset;
 	int xcc_mod_offset;
 	const char *verify_file;
+	const char *strip_file;
 
 	/* SHA 256 & 384 */
 	const char *key_name;
@@ -197,6 +198,8 @@ int pkcs_v1_5_verify_man_v2_5(struct image *image,
 			    struct fw_image_manifest_v2_5 *man,
 			    void *ptr1, unsigned int size1, void *ptr2,
 			    unsigned int size2);
+
+int man_strip_signature_fw(const char *file);
 
 int elf_parse_module(struct image *image, int module_index, const char *name);
 void elf_free_module(struct image *image, int module_index);

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
 
 	image.xcc_mod_offset = DEFAULT_XCC_MOD_OFFSET;
 
-	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:x:f:b:ec:y:")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:x:f:b:ec:y:p:")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;
@@ -88,6 +88,9 @@ int main(int argc, char *argv[])
 		case 'y':
 			image.verify_file = optarg;
 			break;
+		case 'p':
+			image.strip_file = optarg;
+			break;
 		case 'h':
 			usage(argv[0]);
 			break;
@@ -98,6 +101,14 @@ int main(int argc, char *argv[])
 	}
 
 	first_non_opt = optind;
+
+	if (image.strip_file) {
+		ret  = man_strip_signature_fw(image.strip_file);
+		if (ret < 0)
+			fprintf(stderr, "error: can't strip manifest for %s", image.strip_file);
+
+		return ret;
+	}
 
 	/* we must have config */
 	if (!adsp_config) {


### PR DESCRIPTION
CI has a requirment to compare fw content without any
signature to check whether there is no change between
two fw binaries. This patch will strip signature in
signed fw and store it to no_sig_ + fw name.

please check https://github.com/thesofproject/rimage/issues/41

tested on APL & TGL