### PR TITLE
ext_man: Fix memory leak after manifest build

### DIFF
--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -97,7 +97,7 @@ static int ext_man_build(const struct module *module,
 		fprintf(stderr,
 			"error: failed to read %s section content, code %d\n",
 			EXT_MAN_DATA_SECTION, ret);
-		goto out;
+		return ret;
 	}
 	ret = 0;
 
@@ -128,6 +128,7 @@ static int ext_man_build(const struct module *module,
 	*dst_buff = (struct ext_man_header *)buffer;
 
 out:
+	free(sec_buffer);
 	return ret;
 }
 

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -123,7 +123,7 @@ static int ext_man_build(const struct module *module,
 	memcpy(buffer, &ext_man, ext_man.header_size);
 	offset = ext_man.header_size;
 
-	memcpy(&buffer[offset],sec_buffer, section->size);
+	memcpy(&buffer[offset], sec_buffer, section->size);
 
 	*dst_buff = (struct ext_man_header *)buffer;
 


### PR DESCRIPTION
sec_buffer is allocated inside elf_read_section() and as local
variable it's deleted after ext_man_build() exit, so free()
should be called here.