### PR TITLE
Ext man fix mem leak

### DIFF
--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -130,6 +130,7 @@ static int ext_man_build(const struct module *module,
 	*dst_buff = (struct ext_man_header *)buffer;
 
 out:
+	free(sec_buffer);
 	return ret;
 }
 

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -125,7 +125,7 @@ static int ext_man_build(const struct module *module,
 	memcpy(buffer, &ext_man, ext_man.header_size);
 	offset = ext_man.header_size;
 
-	memcpy(&buffer[offset],sec_buffer, section->size);
+	memcpy(&buffer[offset], sec_buffer, section->size);
 
 	*dst_buff = (struct ext_man_header *)buffer;
 


### PR DESCRIPTION
  sec_buffer allocated inside elf_read_section()
  was not being freed before and is freed now.