### PR TITLE
correct Image size for cAVS platforms

### DIFF
--- a/config/apl.toml
+++ b/config/apl.toml
@@ -3,7 +3,7 @@ version = [1, 8]
 [adsp]
 name = "apl"
 machine_id = 5
-image_size = "0x100000"
+image_size = "0x0A0000"        # (8 + 2) bank * 64KB
 
 [[adsp.mem_zone]]
 type = "ROM"

--- a/config/cnl.toml
+++ b/config/cnl.toml
@@ -3,7 +3,7 @@ version = [1, 8]
 [adsp]
 name = "cnl"
 machine_id = 8
-image_size = "0x100000"
+image_size = "0x300000"	# (47 + 1) bank * 64KB
 
 [[adsp.mem_zone]]
 type = "ROM"

--- a/config/icl.toml
+++ b/config/icl.toml
@@ -3,7 +3,7 @@ version = [1, 8]
 [adsp]
 name = "icl"
 machine_id = 9
-image_size = "0x100000"
+image_size = "0x300000"	# (47 + 1) bank * 64KB
 
 [[adsp.mem_zone]]
 type = "ROM"

--- a/config/jsl.toml
+++ b/config/jsl.toml
@@ -1,1 +1,54 @@
-icl.toml
+version = [1, 8]
+
+[adsp]
+name = "icl"
+machine_id = 9
+image_size = "0x110000"	# (16 + 1) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x58"
+length = "0x378"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x400"
+length = "0x60"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x480"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[partition_info]
+name = "ADSP"
+[[partition_info.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -1,1 +1,49 @@
-tgl.toml
+version = [2, 5]
+
+[adsp]
+name = "tgl"
+machine_id = 10
+image_size = "0x1F0000" # (30 + 1) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x9F180000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -3,7 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 machine_id = 10
-image_size = "0x100000"
+image_size = "0x2F0000" # (46 + 1) bank * 64KB
 
 [[adsp.mem_zone]]
 type = "ROM"


### PR DESCRIPTION
    We have 46 bank HP and 1 bank LP SRAM on TGL, change to toml config file
    to reflect that.

    We have 30 bank HP and 1 bank LP SRAM on TGL-H, change to toml config file
    to reflect that.
