### PR TITLE
config: tgl-cavs: change image_size to the real SRAM size

### DIFF
--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -3,7 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 machine_id = 10
-image_size = "0x100000"
+image_size = "0x2F0000"
 
 [[adsp.mem_zone]]
 type = "ROM"


### PR DESCRIPTION
Apply "config: tgl: change image_size to the real SRAM size"
(9e50a02f1b) to tgl-cavs

Signed-off-by: Rander Wang <rander.wang@intel.com>