### PR TITLE
config: sue: change image_size to the real SRAM size

### DIFF
--- a/config/sue.toml
+++ b/config/sue.toml
@@ -3,7 +3,7 @@ version = [1, 5]
 [adsp]
 name = "sue"
 machine_id = 11
-image_size = "0x100000"
+image_size = "0x300000"        # (47 + 1) bank * 64KB
 exec_boot_ldr = 1
 
 [[adsp.mem_zone]]


### PR DESCRIPTION
We have 47 bank HP and 1 bank LP SRAM on Suecreek, change the toml config file
to reflect that.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>