### PR TITLE
config: add rn toml file to support renoir build

### DIFF
--- a/config/rn.toml
+++ b/config/rn.toml
@@ -1,0 +1,16 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "rn"
+machine_id = 14
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x20000000"
+size = "0x40000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x21000000"
+size = "0xE0000"
+host_offset = "0x0"


### PR DESCRIPTION
Add rn toml file to support sof-rn.ri binary build

Signed-off-by: Basavaraj Hiregoudar <basavaraj.hiregoudar@amd.com>
Signed-off-by: Anup Kulkarni <anup.kulkarni@amd.com>
Signed-off-by: balapati <balakishore.pati@amd.com>