### PR TITLE
fixing incorrect data offset in ri_manifest_sign_v1_5

### DIFF
--- a/src/pkcs1_5.c
+++ b/src/pkcs1_5.c
@@ -347,7 +347,8 @@ int ri_manifest_sign_v1_5(struct image *image)
 {
 	struct fw_image_manifest_v1_5 *man = image->fw_image;
 
-	char *const data1 = (char *)man + MAN_CSS_MAN_SIZE_V1_5;
+	/* excluding the manifest header */
+	char *const data1 = (char *)man + sizeof(struct fw_image_manifest_v1_5);
 	unsigned const size1 = image->image_end - sizeof(*man);
 
 	return pkcs_v1_5_sign_man_v1_5(image, man, data1, size1);


### PR DESCRIPTION
It seems that the manifest header is not included for signing (fw_image_manifest_v1_5).

If we are including the header then at least the data1 to be pointed to,
`char *const data1 = (char *)man;`

But in the code, the offset added is MAN_CSS_MAN_SIZE_V1_5 which is 174 (The fw_image_manifest_v1_5 size in words).
`char *const data1 = (char *)man + MAN_CSS_MAN_SIZE_V1_5;`

So, here the offset for data1 can be,

1) 0 (if fw_image_manifest_v1_5 header is included for signing)
2) 696 (which is sizeof(struct fw_image_manifest_v1_5) if header is not included for signing)
It is neither 0 nor 696 but 174 which is the fw_image_manifest_v1_5 size in words.

Moreover, the size that is passed to pkcs_v1_5_sign_man_v1_5 function is,
`unsigned const size1 = image->image_end - sizeof(*man);`

We are subtracting the size of the header here. So, I think we are not including header for signing.
Then the proper offset will be sizeof(struct fw_image_manifest_v1_5).