### PR TITLE
config: Adjust return type with function name

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -134,6 +134,7 @@ static uint32_t parse_uint32_hex_key(const toml_table_t *table, struct parse_ctx
 	if (!raw) {
 		if (def < 0 || def > UINT32_MAX) {
 			*error = err_key_not_found(key);
+			return UINT32_MAX;
 		} else {
 			*error = 0;
 			return (uint32_t)def;
@@ -181,6 +182,7 @@ static uint32_t parse_uint32_key(const toml_table_t *table, struct parse_ctx *ct
 	if (!raw) {
 		if (def < 0 || def > UINT32_MAX) {
 			*error = err_key_not_found(key);
+			return UINT32_MAX;
 		} else {
 			*error = 0;
 			return (uint32_t)def;

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -169,8 +169,8 @@ static uint32_t parse_uint32_hex_key(const toml_table_t *table, struct parse_ctx
  * @param error code, 0 when success
  * @return default, parsed, or UINT32_MAX value
  */
-static int parse_uint32_key(const toml_table_t *table, struct parse_ctx *ctx, const char *key,
-			    int64_t def, int *error)
+static uint32_t parse_uint32_key(const toml_table_t *table, struct parse_ctx *ctx, const char *key,
+				 int64_t def, int *error)
 {
 	toml_raw_t raw;
 	int64_t val;

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -119,7 +119,7 @@ static int assert_everything_parsed(const toml_table_t *table, struct parse_ctx 
  * @param key field name
  * @param def is default value or -1 when value don't have default value
  * @param error code, 0 when success
- * @return default, parsed, or UINT32_MAX value
+ * @return default, parsed, or UINT32_MAX value for error cases
  */
 static uint32_t parse_uint32_hex_key(const toml_table_t *table, struct parse_ctx *ctx,
 				     const char *key, int64_t def, int *error)
@@ -167,7 +167,7 @@ static uint32_t parse_uint32_hex_key(const toml_table_t *table, struct parse_ctx
  * @param key field name
  * @param def is default value or -1 when value don't have default value
  * @param error code, 0 when success
- * @return default, parsed, or UINT32_MAX value
+ * @return default, parsed, or UINT32_MAX value for error cases
  */
 static uint32_t parse_uint32_key(const toml_table_t *table, struct parse_ctx *ctx, const char *key,
 				 int64_t def, int *error)


### PR DESCRIPTION
Function with `parse_uint32` should return uint32_t value

Signed-off-by: Karol Trzcinski <karolx.trzcinski@intel.com>