### PR TITLE
config: Remove machine_id enum

### DIFF
--- a/config/apl.toml
+++ b/config/apl.toml
@@ -2,7 +2,6 @@ version = [1, 8]
 
 [adsp]
 name = "apl"
-machine_id = 5
 image_size = "0x0A0000"        # (8 + 2) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/bdw.toml
+++ b/config/bdw.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "bdw"
-machine_id = 4
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/bsw.toml
+++ b/config/bsw.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "bsw"
-machine_id = 2
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/byt.toml
+++ b/config/byt.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "byt"
-machine_id = 0
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/cht.toml
+++ b/config/cht.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "cht"
-machine_id = 1
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/cnl.toml
+++ b/config/cnl.toml
@@ -2,7 +2,6 @@ version = [1, 8]
 
 [adsp]
 name = "cnl"
-machine_id = 8
 image_size = "0x300000"	# (47 + 1) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/hsw.toml
+++ b/config/hsw.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "hsw"
-machine_id = 3
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/icl.toml
+++ b/config/icl.toml
@@ -2,7 +2,6 @@ version = [1, 8]
 
 [adsp]
 name = "icl"
-machine_id = 9
 image_size = "0x300000"	# (47 + 1) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/imx8.toml
+++ b/config/imx8.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "imx8"
-machine_id = 12
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/imx8m.toml
+++ b/config/imx8m.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "imx8m"
-machine_id = 14
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/imx8ulp.toml
+++ b/config/imx8ulp.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "imx8ulp"
-machine_id = 15
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/imx8x.toml
+++ b/config/imx8x.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "imx8x"
-machine_id = 13
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/jsl.toml
+++ b/config/jsl.toml
@@ -2,7 +2,6 @@ version = [1, 8]
 
 [adsp]
 name = "icl"
-machine_id = 9
 image_size = "0x110000"	# (16 + 1) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/kbl.toml
+++ b/config/kbl.toml
@@ -2,7 +2,6 @@ version = [1, 5]
 
 [adsp]
 name = "kbl"
-machine_id = 6
 image_size = "0x200000" # (30 + 2) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/mt8195.toml
+++ b/config/mt8195.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "mt8195"
-machine_id = 15
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/rn.toml
+++ b/config/rn.toml
@@ -2,7 +2,6 @@ version = [1, 0]  # use simple file write
 
 [adsp]
 name = "rn"
-machine_id = 14
 
 [[adsp.mem_zone]]
 type = "IRAM"

--- a/config/skl.toml
+++ b/config/skl.toml
@@ -2,7 +2,6 @@ version = [1, 5]
 
 [adsp]
 name = "skl"
-machine_id = 7
 image_size = "0x200000" # (30 + 2) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/sue.toml
+++ b/config/sue.toml
@@ -2,7 +2,6 @@ version = [1, 5]
 
 [adsp]
 name = "sue"
-machine_id = 11
 image_size = "0x300000"        # (47 + 1) bank * 64KB
 exec_boot_ldr = 1
 

--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -2,7 +2,6 @@ version = [2, 5]
 
 [adsp]
 name = "tgl"
-machine_id = 10
 image_size = "0x2F0000"
 
 [[adsp.mem_zone]]

--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -2,7 +2,6 @@ version = [2, 5]
 
 [adsp]
 name = "tgl"
-machine_id = 10
 image_size = "0x1F0000" # (30 + 1) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -2,7 +2,6 @@ version = [2, 5]
 
 [adsp]
 name = "tgl"
-machine_id = 10
 image_size = "0x2F0000" # (46 + 1) bank * 64KB
 
 [[adsp.mem_zone]]

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -287,7 +287,6 @@ static void dump_adsp(const struct adsp *adsp)
 
 	DUMP("\nadsp");
 	DUMP_KEY("name", "'%s'", adsp->name);
-	DUMP_KEY("machine_id", "%d", adsp->machine_id);
 	DUMP_KEY("image_size", "0x%x", adsp->image_size);
 	DUMP_KEY("dram_offset", "0x%x", adsp->dram_offset);
 	DUMP_KEY("exec_boot_ldr", "%d", adsp->exec_boot_ldr);
@@ -332,10 +331,6 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 	ret = toml_rtos(raw, (char **)&out->name);
 	if (ret < 0)
 		return err_key_parse("name", NULL);
-
-	out->machine_id = parse_uint32_key(adsp, &ctx, "machine_id", -1, &ret);
-	if (ret < 0)
-		return ret;
 
 	out->image_size = parse_uint32_hex_key(adsp, &ctx, "image_size", 0, &ret);
 	if (ret < 0)
@@ -2110,7 +2105,8 @@ static int parse_adsp_config_v1_5(const toml_table_t *toml, struct adsp *out,
 	if (ret < 0)
 		return err_key_parse("adsp", NULL);
 
-	if (out->machine_id == MACHINE_SUECREEK) {
+	/* suecreek has dedicated manifest file */
+	if (!strcmp(out->name, "sue")) {
 		/* out free is done in client code */
 		out->man_v1_5_sue = malloc(sizeof(struct fw_image_manifest_v1_5_sue));
 		if (!out->man_v1_5_sue)

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -24,27 +24,6 @@ struct adsp;
 struct manifest;
 struct man_module;
 
-/* list of supported targets */
-enum machine_id {
-	MACHINE_BAYTRAIL	= 0,
-	MACHINE_CHERRYTRAIL,
-	MACHINE_BRASWELL,
-	MACHINE_HASWELL,
-	MACHINE_BROADWELL,
-	MACHINE_APOLLOLAKE,
-	MACHINE_KABYLAKE,
-	MACHINE_SKYLAKE,
-	MACHINE_CANNONLAKE,
-	MACHINE_ICELAKE,
-	MACHINE_TIGERLAKE,
-	MACHINE_SUECREEK,
-	MACHINE_IMX8,
-	MACHINE_IMX8X,
-	MACHINE_IMX8M,
-	MACHINE_MT8195,
-	MACHINE_MAX
-};
-
 /*
  * ELF module data
  */
@@ -171,7 +150,6 @@ struct adsp {
 	uint32_t image_size;
 	uint32_t dram_offset;
 
-	enum machine_id machine_id;
 	int (*write_firmware_ext_man)(struct image *image);
 	int (*write_firmware)(struct image *image);
 	int (*write_firmware_meu)(struct image *image);


### PR DESCRIPTION
This enum value is used only to distinguish suecreek from other
platforms, which can be done also by platform name.

Manual enumeration, in separate toml files with manual synchronization
in enum definition is quite error prone. After commit
9bf46d3: "rimage: Add support for mt8195" and
9716e10: "config: Add imx8ulp.toml" there are two different
platform with the same enum value 15 specified, which proves such a
thesis.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>