### PR TITLE
rimage: Fix error message content after adsp malloc fail

### DIFF
--- a/src/rimage.c
+++ b/src/rimage.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
 	/* find machine */
 	heap_adsp = malloc(sizeof(struct adsp));
 	if (!heap_adsp) {
-		fprintf(stderr, "error: cannot parse build version\n");
+		fprintf(stderr, "error: memory allocation for adsp struct failed\n");
 		return -ENOMEM;
 	}
 	image.adsp = heap_adsp;


### PR DESCRIPTION
Message should reflect error root cause.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>