### PR TITLE
ext_manifest: Fix incorrect signature

### DIFF
--- a/src/include/rimage/sof/kernel/ext_manifest.h
+++ b/src/include/rimage/sof/kernel/ext_manifest.h
@@ -33,8 +33,8 @@
 #define __packed __attribute__((packed))
 #endif
 
-/* In ASCII `XMan` */
-#define EXT_MAN_MAGIC_NUMBER	0x6e614d58
+/* In ASCII `$AE1` */
+#define EXT_MAN_MAGIC_NUMBER	0x31454124
 
 /* Build u32 number in format MMmmmppp */
 #define EXT_MAN_BUILD_VERSION(MAJOR, MINOR, PATH) ( \


### PR DESCRIPTION
This patch changes the incorrect signature of extended manifest
to the correct one "$AE1"

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>