### PR TITLE
remove '-x' option

### DIFF
--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -84,7 +84,6 @@ struct image {
 	struct module module[MAX_MODULES];
 	uint32_t image_end;/* module end, equal to output image size */
 	int meu_offset;
-	int xcc_mod_offset;
 	const char *verify_file;
 
 	/* SHA 256 & 384 */

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -264,12 +264,7 @@ static int man_get_module_manifest(struct image *image, struct module *module,
 	section = &module->section[man_section_idx];
 
 	/* load in manifest data */
-	/* module built using xcc has preceding bytes */
-	if (section->size > sizeof(sof_mod))
-		ret = fseek(module->fd,
-			    section->off + image->xcc_mod_offset, SEEK_SET);
-	else
-		ret = fseek(module->fd, section->off, SEEK_SET);
+	ret = fseek(module->fd, section->off, SEEK_SET);
 
 	if (ret < 0) {
 		fprintf(stderr, "error: can't seek to section %d\n", ret);

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -26,7 +26,6 @@ static void usage(char *name)
 	fprintf(stdout, "\t -r enable relocatable ELF files\n");
 	fprintf(stdout, "\t -s MEU signing offset, disables rimage signing\n");
 	fprintf(stdout, "\t -i set IMR type\n");
-	fprintf(stdout, "\t -x set xcc module offset\n");
 	fprintf(stdout, "\t -f firmware version = x.y\n");
 	fprintf(stdout, "\t -b build version\n");
 	fprintf(stdout, "\t -e build extended manifest\n");
@@ -44,8 +43,6 @@ int main(int argc, char *argv[])
 	int use_ext_man = 0;
 
 	memset(&image, 0, sizeof(image));
-
-	image.xcc_mod_offset = DEFAULT_XCC_MOD_OFFSET;
 
 	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:x:f:b:ec:y:")) != -1) {
 		switch (opt) {
@@ -69,9 +66,6 @@ int main(int argc, char *argv[])
 			break;
 		case 'i':
 			imr_type = atoi(optarg);
-			break;
-		case 'x':
-			image.xcc_mod_offset = atoi(optarg);
 			break;
 		case 'f':
 			image.fw_ver_string = optarg;


### PR DESCRIPTION
This patch removes the unnecessary and unscalable -x option.
This option aims to add an offset to the .data section of
its parent .module section. This is horrible idea because this
offset will vary depend on the compiler used. It is better and
much easier to just store only the .data section so the offset
is always 0.

SoF FW related change -> https://github.com/thesofproject/sof/pull/4762

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>