### PR TITLE
[RFC] rimage: use sof default UUID

### DIFF
--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -55,7 +55,7 @@ load_offset = "0x30000"
 count = 7
 	[[module.entry]]
 	name = "BRNGUP"
-	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
+	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
 	affinity_mask = "0x1"
 	instance_count = "1"
 	domain_types = "0"
@@ -65,7 +65,7 @@ count = 7
 
 	[[module.entry]]
 	name = "BASEFW"
-	uuid = "383B9BE2-3518-4DB0-8891-B1470A8914F8"
+	uuid = "0E398C32-5ADE-BA4B-93B1-C50432280EE4"
 	affinity_mask = "3"
 	instance_count = "1"
 	domain_types = "0"


### PR DESCRIPTION
Rimage builds UUID in module config based on sof fw but
UUID in extented manifest is based on tgl-cavs.toml which
use UUID in cavs fw. Now use sof UUID to build extented
manifest.

Tested with windows driver.


And for built-in module, we may use our own UUID. We need to confirm it when we can do playback on windows 

In future, we can get UUID in sof fw after we confirm above idea, but now this is not in high priority. We need to make basic playback  work on windows first.