### PR TITLE
Revert "ext_manifest: Fix incorrect signature"

### DIFF
--- a/src/include/rimage/sof/kernel/ext_manifest.h
+++ b/src/include/rimage/sof/kernel/ext_manifest.h
@@ -33,8 +33,8 @@
 #define __packed __attribute__((packed))
 #endif
 
-/* In ASCII `$AE1` */
-#define EXT_MAN_MAGIC_NUMBER	0x31454124
+/* In ASCII `XMan` */
+#define EXT_MAN_MAGIC_NUMBER	0x6e614d58
 
 /* Build u32 number in format MMmmmppp */
 #define EXT_MAN_BUILD_VERSION(MAJOR, MINOR, PATH) ( \


### PR DESCRIPTION
This reverts commit 241af313dab49db06d6e6f0af3330f1a916de664 so the DSP
can boot again.

On my APL UP2 this fixes:
```
10:06:38: 00:0e.0: unstall/run core: core_mask = 1
10:06:38: 00:0e.0: DSP core(s) enabled? 1 : core_mask 1
10:06:38: 00:0e.0: FW Poll Status: reg[0x4c]=0x40000000 successful
10:06:38: 00:0e.0: FW Poll Status: reg[0x4]=0x3030202 successful
10:06:38: 00:0e.0: FW Poll Status: reg[0x4]=0x1010202 successful
10:06:38: 00:0e.0: DSP core(s) enabled? 0 : core_mask 2
10:06:38: 00:0e.0: FW Poll Status: reg[0x80000]=0x5000001 successful
10:06:41: 00:0e.0: FW Poll Status: reg[0x80000]=0x80000007 timedout
10:06:41: 00:0e.0: error: cl_copy_fw: timeout HDA_DSP_SRAM_REG_ROM_STATUS read
10:06:41: 00:0e.0: FW Poll Status: reg[0x160]=0x140000 successful
10:06:41: 00:0e.0: ------------[ DSP dump start ]------------
10:06:41: 00:0e.0: unknown ROM status value 80000007
10:06:41: 00:0e.0: error: extended rom status:  0x80000007 0x2f 0x0 0x0 \
                                                0x0 0x0 0x1522100 0x0
10:06:41: 00:0e.0: ------------[ DSP dump end ]------------
10:06:41: 00:0e.0: error: load fw failed ret: -110
10:06:41: 00:0e.0: error: failed to start DSP
10:06:41: 00:0e.0: error: failed to boot DSP firmware -110
10:06:41: 00:0e.0: FW Poll Status: reg[0x4]=0x1d003c timedout
10:06:41: 00:0e.0: error: hda_dsp_core_reset_enter: timeout on  \
                                                  HDA_DSP_REG_ADSPCS read
10:06:41: 00:0e.0: error: dsp core reset failed: core_mask 3
10:06:41: probe of 0000:00:0e.0 failed with error -110
```
Test PR https://github.com/thesofproject/sof/pull/4782 show this commit
broke the DSP boot on ALL platforms
  https://sof-ci.01.org/sofpr/PR4782/build10387/devicetest/

```
[    7.798750] kernel: sof-audio-acpi-intel-bdw INT3438:00: error: invalid firmware signature
[    7.798827] kernel: sof-audio-acpi-intel-bdw INT3438:00: error: invalid FW header
[    7.798943] kernel: sof-audio-acpi-intel-bdw INT3438:00: error: failed to load DSP firmware -22
[    7.810348] kernel: sof-audio-acpi-intel-bdw INT3438:00: error:
sof_probe_work failed err: -22
```

This also broke QEMU boot on a number of platforms: BDW, BYT and CHT, see
`error: invalid firmware signature` in

https://sof-ci.01.org/sofpr/PR4782/build10387/boottest/ and
https://github.com/thesofproject/sof/pull/4782/checks?check_run_id=3634915322

How was it tested?

Signed-off-by: Marc Herbert <marc.herbert@intel.com>