### PR TITLE
css.c: add __func__  to "completing manifest" log

### DIFF
--- a/src/css.c
+++ b/src/css.c
@@ -19,7 +19,7 @@ void ri_css_v2_5_hdr_create(struct image *image)
 	time_t seconds;
 	int val;
 
-	fprintf(stdout, " cse: completing CSS manifest\n");
+	fprintf(stdout, " cse: %s completing CSS manifest\n", __func__);
 
 	/* get local time and date */
 	gettimeofday(&tv, NULL);
@@ -76,7 +76,7 @@ void ri_css_v1_8_hdr_create(struct image *image)
 	time_t seconds;
 	int val;
 
-	fprintf(stdout, " cse: completing CSS manifest\n");
+	fprintf(stdout, " cse: %s completing CSS manifest\n", __func__);
 
 	/* get local time and date */
 	gettimeofday(&tv, NULL);
@@ -133,7 +133,7 @@ void ri_css_v1_5_hdr_create(struct image *image)
 	time_t seconds;
 	int val;
 
-	fprintf(stdout, " cse: completing CSS manifest\n");
+	fprintf(stdout, " cse: %s completing CSS manifest\n", __func__);
 
 	/* get local time and date */
 	gettimeofday(&tv, NULL);


### PR DESCRIPTION
This is useful to show which one of the 3 duplicated functions runs.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>