### PR TITLE
[RFC] rimage: add functionality to resign fw image

### DIFF
--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -73,6 +73,7 @@ struct module {
 struct image {
 
 	const char *out_file;
+	const char *in_file;
 	FILE *out_fd;
 	void *pos;
 
@@ -200,6 +201,9 @@ int pkcs_v1_5_verify_man_v2_5(struct image *image,
 			    struct fw_image_manifest_v2_5 *man,
 			    void *ptr1, unsigned int size1, void *ptr2,
 			    unsigned int size2);
+
+int resign_image(struct image *image);
+int get_key_size(struct image *image);
 
 int elf_parse_module(struct image *image, int module_index, const char *name);
 void elf_free_module(struct image *image, int module_index);

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -30,6 +30,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -b build version\n");
 	fprintf(stdout, "\t -e build extended manifest\n");
 	fprintf(stdout, "\t -y verify signed file\n");
+	fprintf(stdout, "\t -q resign binary\n");
 }
 
 int main(int argc, char *argv[])
@@ -43,7 +44,7 @@ int main(int argc, char *argv[])
 
 	memset(&image, 0, sizeof(image));
 
-	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:x:f:b:ec:y:")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:x:f:b:ec:y:q:")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;
@@ -84,6 +85,9 @@ int main(int argc, char *argv[])
 		case 'h':
 			usage(argv[0]);
 			return 0;
+		case 'q':
+			image.in_file = optarg;
+			break;
 		default:
 		 /* getopt's default error message is good enough */
 			return 1;
@@ -150,6 +154,11 @@ int main(int argc, char *argv[])
 	if (image.verify_file) {
 		ret = verify_image(&image);
 		goto out;
+	}
+
+	if (image.in_file) {
+		fprintf(stdout, "going to re-sign\n");
+		return resign_image(&image);
 	}
 
 	/* set IMR Type in found machine definition */


### PR DESCRIPTION
Add function to resign already signed images. This can
be done with switch "q" as follows:

"rimage -q sof-tgl.ri -o sof-tgl-mod.ri -c tgl.toml -k key.pem"

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>