### PR TITLE
manifest: fix buffer init in resign

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1432,9 +1432,9 @@ out:
 int resign_image(struct image *image)
 {
 	int key_size, key_file_size;
+	void *buffer = NULL;
 	size_t size, read;
 	FILE *in_file;
-	void *buffer;
 	int ret, i;
 
 	/* open image for reading */


### PR DESCRIPTION
Set buffer to NULL to prevent freeing bogus memory in error case.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>