### PR TITLE
remove x from getopt

### DIFF
--- a/src/rimage.c
+++ b/src/rimage.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 
 	memset(&image, 0, sizeof(image));
 
-	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:x:f:b:ec:y:q:")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;


### PR DESCRIPTION
x param was removed from switch case but not from getopt. So if you use
x rimage silently fails on the switch case.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>