### PR TITLE
adsp_config: fix invalid format specifier

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -2023,7 +2023,7 @@ static int parse_module(const toml_table_t *toml, struct parse_ctx *pctx,
 		if (strcmp((char *)mod_man->name, "BRNGUP") &&
 		    strcmp((char *)mod_man->name, "BASEFW")) {
 			if (type != i - 1) {
-				log_err(ret, "error: invalid type %s", type);
+				log_err(ret, "error: invalid type %d", type);
 				return -EINVAL;
 			}
 		}


### PR DESCRIPTION
This patch fixes an invalid format specifier that causes a numeric value
to be interpreted as a string, resulting in an Segmentation fault.