### PR TITLE
Update to C99 standard to match SOF. Silenced warning generated by newer gcc versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,17 @@ add_executable(rimage
 	tomlc99/toml.c
 )
 
+set_property(TARGET rimage PROPERTY C_STANDARD 99)
+
 target_compile_options(rimage PRIVATE
 	-Wall -Werror -Wmissing-prototypes -Wimplicit-fallthrough
 )
 
-target_link_libraries(rimage PRIVATE "-lcrypto")
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 9.1)
+	target_compile_options(rimage PRIVATE -Wno-char-subscripts)
+endif()
+
+target_link_libraries(rimage PRIVATE crypto)
 
 target_include_directories(rimage PRIVATE
 	src/include/


### PR DESCRIPTION
Update to C99 standard to match SOF. Silenced warning generated by newer GCC compilers related to int cast of char typed values that may result in negative values. Analyzed the code where warning occurs. Values typed char where warning is shown are passed to C standard isdigit function that handles cases when char returns negative value as int so no harm done.
Syntax fix in CMake function target_link_libraries - linkage of crypto library to more generic approach.
In CMake documentation adding a library should look like this. When compiler other than GCC is used other (matching that compiler) linker flag is generated.