### PR TITLE
Resurrect Windows build and upgrade CMake version to match Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,27 @@ if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 9.1)
 	target_compile_options(rimage PRIVATE -Wno-char-subscripts)
 endif()
 
+# Windows builds use MSYS2 https://www.msys2.org/ to get linux tools and headers.
+# MSYS_INSTALL_DIR variable points to MSYS2 installation directory.
+# You may pass it as environmental or cmake configure variable.
+if(${CMAKE_HOST_WIN32})
+	cmake_minimum_required(VERSION 3.20)
+	if(DEFINED ENV{MSYS_INSTALL_DIR} AND NOT MSYS_INSTALL_DIR)
+		set(MSYS_INSTALL_DIR $ENV{MSYS_INSTALL_DIR})
+	endif()
+
+	if(MSYS_INSTALL_DIR)
+		cmake_path(IS_ABSOLUTE MSYS_INSTALL_DIR IS_MSYS_INSTALL_DIR_ABSOLUTE)
+		if(NOT IS_MSYS_INSTALL_DIR_ABSOLUTE)
+			message(FATAL_ERROR "Please provide absolute path to MSYS2 installation
+				setting MSYS_INSTALL_DIR env variable")
+		endif()
+		# Include standard posix headers. Requires pacman openssl-devel package.
+		cmake_path(APPEND MSYS_INSTALL_DIR "usr" "include" OUTPUT_VARIABLE MSYS_SYSTEM_INCLUDE_PATH)
+		target_include_directories(rimage PRIVATE "${MSYS_SYSTEM_INCLUDE_PATH}")
+	endif()
+endif()
+
 target_link_libraries(rimage PRIVATE crypto)
 
 target_include_directories(rimage PRIVATE

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// Copyright(c) 2018 Intel Corporation. All rights reserved.
+// Copyright(c) 2018-2022 Intel Corporation. All rights reserved.
 //
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Keyon Jie <yang.jie@linux.intel.com>
@@ -1480,7 +1480,7 @@ int resign_image(struct image *image)
 	/* read file into buffer */
 	read = fread(buffer, 1, size, in_file);
 	if (read != size) {
-		fprintf(stderr, "error: unable to read %ld bytes from %s err %d\n",
+		fprintf(stderr, "error: unable to read %zu bytes from %s err %d\n",
 					size, image->in_file, errno);
 		ret = errno;
 		goto out;


### PR DESCRIPTION
Two commits:
1) Added handling of OpenSSL on Windows using OPENSSL_PATH.
Upgraded CMake minimal version to 3.20.0 to match Zephyr and to use cmake_path freely.
2) Fixed warning treated as error in src/manifest.c where variable passed to fprintf was of type size_t and expected format of long int.

Signed-off-by: Andrey Borisovich [andrey.borisovich@intel.com](mailto:andrey.borisovich@intel.com)