### PR TITLE
Fix confusion in headers between uint8_t arrays and strings

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -627,7 +627,7 @@ static int parse_cse_v2_5(const toml_table_t *toml, struct parse_ctx *pctx,
 
 	hdr->nb_entries = toml_array_nelem(cse_entry_array);
 
-	if (1 || verbose)
+	if (verbose)
 		dump_cse_v2_5(hdr, out);
 
 	/*


### PR DESCRIPTION
2 commits. Main one:

Fix confusion in headers between uint8_t arrays and strings 

Strings are null terminated, byte arrays not always.

Fixes garbage in debug output issue #86

Change parse_str_key() argument from char * to uint8_t *. Casting the
argument on almost every call was a clear indication of the problem.

Add new DUMP_PRINTABLE_BYTES() to printf uint8_t arrays _and_ their
_optional_ padding.

No change to the .ri output, bit for bit identical.

Here's an example of how the -v output is fixed:

```diff
    mem_zone.host_offset: 0x0

 cse
-         partition_name: 'ADSPADSP.man'
+         partition_name: ADSP
          header_version: 1
           entry_version: 1
              nb_entries: 3
-             entry.name: 'ADSP.man'
+             entry.name: ADSP.man\x00\x00\x00\x00
            entry.offset: 0x58
            entry.length: 0x378
-             entry.name: 'cavs0015.met'
+             entry.name: cavs0015.met
            entry.offset: 0x400
            entry.length: 0x60
-             entry.name: 'cavs0015'
+             entry.name: cavs0015\x00\x00\x00\x00
            entry.offset: 0x480
            entry.length: 0x0

@@ -140,7 +132,7 @@
           exponent_size: 1

 signed_pkg
-                   name: 'ADSP'
+                   name: ADSP
                     vcn: 0
                     svn: 0
                 fw_type: 0
@@ -161,17 +153,17 @@
                  bitmap: 0
                  bitmap: 0
                  bitmap: 0
-              meta.name: 'cavs0015.met^C^B '
+              meta.name: cavs0015.met
               meta.type: 0x3
          meta.hash_algo: 0x2
          meta.hash_size: 0x20
          meta.meta_size: 96

 partition_info
-                   name: 'ADSP'
+                   name: ADSP
            part_version: 0x10000000
             instance_id: 1
-            module.name: 'cavs0015.met^C'
+            module.name: cavs0015.met
        module.meta_size: 0x60
             module.type: 0x3

@@ -186,7 +178,7 @@

 fw_desc.header
               header_id: '$AM1'
-                   name: 'ADSPFW'
+                   name: ADSPFW\x00\x00
      preload_page_count: 0
          fw_image_flags: 0x0
            feature_mask: 0xffff
```

Signed-off-by: Marc Herbert <marc.herbert@intel.com>