### PR TITLE
Write firmware file micro version to manifest for cAVS platforms

### DIFF
--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -199,6 +199,7 @@ int ext_man_write_cavs_25(struct image *image)
 
 	header.version_major = mod_ext->ext_mod_config_array->header.version_major;
 	header.version_minor = mod_ext->ext_mod_config_array->header.version_minor;
+	header.version_micro = mod_ext->ext_mod_config_array->header.version_micro;
 	header.num_module_entries = count;
 	header.id = EXTENDED_MANIFEST_MAGIC_HEADER_ID;
 	header.len = sizeof(const struct fw_ext_man_cavs_header);

--- a/src/include/rimage/cavs/cavs_ext_manifest.h
+++ b/src/include/rimage/cavs/cavs_ext_manifest.h
@@ -230,6 +230,7 @@ struct fw_ext_man_cavs_header {
 	uint32_t len;	/* sizeof(Extend Manifest) in bytes */
 	uint16_t version_major;	/* Version of Extended Manifest structure */
 	uint16_t version_minor;	/* Version of Extended Manifest structure */
+	uint16_t version_micro; /* Version of Extended Manifest structure */
 	uint32_t num_module_entries;
 } __attribute__((packed));
 
@@ -238,7 +239,7 @@ struct fw_ext_mod_config_header {
 	uint32_t guid[4];	/* Module GUID */
 	uint16_t version_major;	/* Module version */
 	uint16_t version_minor;	/* Module version */
-	uint16_t version_hotfix;	/* Module version */
+	uint16_t version_micro;	/* Module version */
 	uint16_t version_build;	/* Module version */
 	enum mod_type module_type;
 	uint32_t init_settings_min_size;	/* Minimum size of initialization settings (in bytes) */

--- a/src/include/rimage/css.h
+++ b/src/include/rimage/css.h
@@ -40,7 +40,7 @@ struct image;
 struct fw_version {
 	uint16_t major_version;
 	uint16_t minor_version;
-	uint16_t hotfix_version;
+	uint16_t micro_version;
 	uint16_t build_version;
 } __attribute__((packed));
 

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -109,6 +109,7 @@ struct image {
 	char* fw_ver_build_string;
 	uint16_t fw_ver_major;
 	uint16_t fw_ver_minor;
+	uint16_t fw_ver_micro;
 	uint16_t fw_ver_build;
 };
 

--- a/src/include/rimage/sof/user/manifest.h
+++ b/src/include/rimage/sof/user/manifest.h
@@ -134,7 +134,7 @@ struct sof_man_fw_header {
 	uint32_t feature_mask;
 	uint16_t major_version;
 	uint16_t minor_version;
-	uint16_t hotfix_version;
+	uint16_t micro_version;
 	uint16_t build_version;
 	uint32_t num_module_entries;
 	uint32_t hw_buf_base_addr;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -776,6 +776,7 @@ int man_write_fw_v1_5(struct image *image)
 	/* firmware and build version */
 	m->desc.header.major_version = image->fw_ver_major;
 	m->desc.header.minor_version = image->fw_ver_minor;
+	m->desc.header.micro_version = image->fw_ver_micro;
 	m->desc.header.build_version = image->fw_ver_build;
 
 	/* create each module */
@@ -845,6 +846,7 @@ int man_write_fw_v1_5_sue(struct image *image)
 	/* firmware and build version */
 	m->desc.header.major_version = image->fw_ver_major;
 	m->desc.header.minor_version = image->fw_ver_minor;
+	m->desc.header.micro_version = image->fw_ver_micro;
 	m->desc.header.build_version = image->fw_ver_build;
 
 	/* create each module - subtract the boot loader exec header */
@@ -913,9 +915,11 @@ int man_write_fw_v1_8(struct image *image)
 	/* firmware and build version */
 	m->css.version.major_version = image->fw_ver_major;
 	m->css.version.minor_version = image->fw_ver_minor;
+	m->css.version.micro_version = image->fw_ver_micro;
 	m->css.version.build_version = image->fw_ver_build;
 	m->desc.header.major_version = image->fw_ver_major;
 	m->desc.header.minor_version = image->fw_ver_minor;
+	m->desc.header.micro_version = image->fw_ver_micro;
 	m->desc.header.build_version = image->fw_ver_build;
 
 	/* create each module */
@@ -1022,6 +1026,7 @@ int man_write_fw_meu_v1_5(struct image *image)
 	/* firmware and build version */
 	desc->header.major_version = image->fw_ver_major;
 	desc->header.minor_version = image->fw_ver_minor;
+	desc->header.micro_version = image->fw_ver_micro;
 	desc->header.build_version = image->fw_ver_build;
 
 	/* create each module */
@@ -1102,6 +1107,7 @@ int man_write_fw_meu_v1_8(struct image *image)
 	/* firmware and build version */
 	desc->header.major_version = image->fw_ver_major;
 	desc->header.minor_version = image->fw_ver_minor;
+	desc->header.micro_version = image->fw_ver_micro;
 	desc->header.build_version = image->fw_ver_build;
 
 	/* create each module */
@@ -1182,6 +1188,7 @@ int man_write_fw_meu_v2_5(struct image *image)
 	/* firmware and build version */
 	desc->header.major_version = image->fw_ver_major;
 	desc->header.minor_version = image->fw_ver_minor;
+	desc->header.micro_version = image->fw_ver_micro;
 	desc->header.build_version = image->fw_ver_build;
 
 	/* create each module */
@@ -1263,9 +1270,11 @@ int man_write_fw_v2_5(struct image *image)
 	/* firmware and build version */
 	m->css.version.major_version = image->fw_ver_major;
 	m->css.version.minor_version = image->fw_ver_minor;
+	m->css.version.micro_version = image->fw_ver_micro;
 	m->css.version.build_version = image->fw_ver_build;
 	m->desc.header.major_version = image->fw_ver_major;
 	m->desc.header.minor_version = image->fw_ver_minor;
+	m->desc.header.micro_version = image->fw_ver_micro;
 	m->desc.header.build_version = image->fw_ver_build;
 
 	/* create each module */

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -115,19 +115,21 @@ int main(int argc, char *argv[])
 		return -EINVAL;
 	}
 
-	/* firmware version and build id */
+	/* firmware version that can be major.minor or major.minor.micro */
 	if (image.fw_ver_string) {
-		ret = sscanf(image.fw_ver_string, "%hu.%hu",
+		ret = sscanf(image.fw_ver_string, "%hu.%hu.%hu",
 			     &image.fw_ver_major,
-			     &image.fw_ver_minor);
+			     &image.fw_ver_minor,
+			     &image.fw_ver_micro);
 
-		if (ret != 2) {
+		if (ret != 2 && ret != 3) {
 			fprintf(stderr,
 				"error: cannot parse firmware version\n");
 			return -EINVAL;
 		}
 	}
 
+	/* firmware build id */
 	if (image.fw_ver_build_string) {
 		ret = sscanf(image.fw_ver_build_string, "%hu",
 			     &image.fw_ver_build);


### PR DESCRIPTION
Fix https://github.com/thesofproject/rimage/issues/90

SOF CMake defines SOF_MAJOR, SOF_MINOR and SOF_MICRO for 3 fields
of firmware file version major.minor.micro

This patch changes hotfix_version to micro_version in headers to align
with SOF CMake, and adds fw_ver_micro to firmware image context.

If SOF CMake passes firmware file micro version in the version string,
rimage will write it to different manifest headers for cAVS platforms.
If micro version isn't passed to rimage, it's 0 by default.

This feature will allow sof_ri_info.py to dump entire file version from
a FW binary for cAVS platforms.

There will be a SOF PR to let CMake pass FW file micro version to rimage.