### PR TITLE
Make micro version optional for firmware file version string argument

### DIFF
--- a/src/rimage.c
+++ b/src/rimage.c
@@ -26,7 +26,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -r enable relocatable ELF files\n");
 	fprintf(stdout, "\t -s MEU signing offset, disables rimage signing\n");
 	fprintf(stdout, "\t -i set IMR type\n");
-	fprintf(stdout, "\t -f firmware version = major.minor.micro\n");
+	fprintf(stdout, "\t -f firmware version = major.minor or major.minor.micro\n");
 	fprintf(stdout, "\t -b build version\n");
 	fprintf(stdout, "\t -e build extended manifest\n");
 	fprintf(stdout, "\t -y verify signed file\n");
@@ -122,9 +122,9 @@ int main(int argc, char *argv[])
 			     &image.fw_ver_minor,
 			     &image.fw_ver_micro);
 
-		if (ret != 3) {
+		if (ret != 2 && ret != 3) {
 			fprintf(stderr,
-				"error: cannot parse firmware version major.minor.micro\n");
+				"error: cannot parse firmware version major.minor or major.minor.micro\n");
 			return -EINVAL;
 		}
 	}


### PR DESCRIPTION
This is a preparation to fix https://github.com/thesofproject/sof/issues/5775. Another SOF PR https://github.com/thesofproject/sof/pull/5846 is to update xtensa-build-zephyr.py

rimage can accept firmware file version string like major.minor
or major.minor.micro. The 3rd field 'micro' is optional.

For building with XOTS, SOF CMake always passes version string
major.minor.micro to rimage.

But for building with Zephyr, xtensa-build-zephyr.py will extract
version string from latest git tag which can be either major.minor
or major.minor.micro

Signed-off-by: mengdonglin <mengdong.lin@intel.com>