### PR TITLE
manifest max size for loadable modules

### DIFF
--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -13,6 +13,7 @@
 #include <rimage/plat_auth.h>
 
 #define MAN_PAGE_SIZE		4096
+#define MAN_MAX_SIZE_V1_8       (38 * 1024)
 
 /* start offset for modules built using xcc */
 #define DEFAULT_XCC_MOD_OFFSET		0x8


### PR DESCRIPTION
Library manager during loading modules needs manifest max size

Signed-off-by: Dobrowolski, PawelX <pawelx.dobrowolski@intel.com>