### PR TITLE
mtl: Add UPDWMIX module to the manifest

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -49,7 +49,7 @@ name = "ADSPFW"
 load_offset = "0x40000"
 
 [module]
-count = 10
+count = 11
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
@@ -299,3 +299,28 @@ count = 10
 	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
 			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
 			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]
+
+	[[module.entry]]
+	name = "UPDWMIX"
+	uuid = "42F8060C-832F-4DBF-B247-51E961997B34"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
+			1, 0, 0xffff, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 216, 706000, 12, 16, 0, 0, 0,
+				1, 0, 0, 0, 216, 1271000, 8, 8, 0, 0, 0,
+				2, 0, 0, 0, 216, 1839000, 89, 118, 0, 0, 0,
+				3, 0, 0, 0, 216, 2435000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 216, 3343000, 192, 192, 0, 0, 0,
+				5, 0, 0, 0, 216, 3961000, 177, 177, 0, 0, 0,
+				6, 0, 0, 0, 216, 4238000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 216, 6691000, 192, 256, 0, 0, 0]


### PR DESCRIPTION
Added Up Down Mixer module to config/mtl.toml
Increased modules count.

Signed-off-by: Arsen Eloglian <ArsenX.Eloglian@intel.com>