### PR TITLE
rimage: add error message in the openssl 3.0 stub

### DIFF
--- a/src/pkcs1_5.c
+++ b/src/pkcs1_5.c
@@ -631,6 +631,7 @@ int pkcs_v1_5_sign_man_ace_v1_5(struct image *image,
 			    void *ptr1, unsigned int size1, void *ptr2,
 			    unsigned int size2)
 {
+	fprintf(stderr, "error: OPENSSL_VERSION_NUMBER >= 0x30000000L is not supported\n");
 	return -EINVAL;
 }
 #endif


### PR DESCRIPTION
The error status caused by unsupported openssl is cryptic:

"FATAL ERROR: command exited with status 234:..."

Add an error message to save troubleshooting time.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>