### PR TITLE
mux: add mux cfg to list of modules

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -49,7 +49,7 @@ name = "ADSPFW"
 load_offset = "0x40000"
 
 [module]
-count = 12
+count = 13
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
@@ -338,3 +338,21 @@ count = 12
 
 	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 100000, 48, 48, 0, 1000, 0]
+	
+ 	[[module.entry]]
+	name = "MUX"
+	uuid = "64ce6e35-857a-4878-ace8-e2a2f42e3069"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0xB"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 280, 460700, 16, 16, 0, 0, 0]


### PR DESCRIPTION
No mux in the manifest

Signed-off-by: Kwasowiec, Fabiola <fabiola.kwasowiec@intel.com>