### PR TITLE
mux: fix module type

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -346,7 +346,7 @@ count = 13
 	instance_count = "15"
 	domain_types = "0"
 	load_type = "1"
-	module_type = "0xB"
+	module_type = "11"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 


### PR DESCRIPTION
error: invalid type /error: key 'module' parsing error

Signed-off-by: Kwasowiec, Fabiola <fabiola.kwasowiec@intel.com>