### PR TITLE
probe: mtl.toml invaliv probe type

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -332,7 +332,7 @@ count = 13
 	instance_count = "1"
 	domain_types = "0"
 	load_type = "0"
-	module_type = "10"
+	module_type = "0xA"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
@@ -346,7 +346,7 @@ count = 13
 	instance_count = "15"
 	domain_types = "0"
 	load_type = "1"
-	module_type = "11"
+	module_type = "0xB"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 


### PR DESCRIPTION
error: invalid type 16error: key 'module' parsing error probe module type is 10,which is treated hexally

Signed-off-by: Kwasowiec, Fabiola <fabiola.kwasowiec@intel.com>