### PR TITLE
config: tgl-cavs: add smart_amp module config

### DIFF
--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -52,7 +52,7 @@ name = "ADSPFW"
 load_offset = "0x30000"
 
 [module]
-count = 9
+count = 10
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
@@ -266,3 +266,23 @@ count = 9
 		20, 0, 0, 0, 12832, 20881000, 0, 0, 0, 20881, 0,
 		21, 0, 0, 0, 12832, 23431000, 0, 0, 0, 23431, 0,
 		22, 0, 0, 0, 12832, 30471000, 0, 0, 0, 30471, 0]
+
+	# smart amp test module config
+	[[module.entry]]
+	name = "SMATEST"
+	uuid = "167A961E-8AE4-11EA-89F1-000C29CE1635"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "8"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]


### PR DESCRIPTION
This patch adds module config for smart_amp.

Signed-off-by: Chao Song <chao.song@linux.intel.com>