### PR TITLE
Add a command line option to set production bit

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -974,8 +974,10 @@ static void dump_signed_pkg(const struct signed_pkg_info_ext *signed_pkg)
 }
 
 static int parse_signed_pkg(const toml_table_t *toml, struct parse_ctx *pctx,
-			    struct signed_pkg_info_ext *out, bool verbose)
+			    struct image *image, bool verbose)
 {
+	struct adsp *adsp = image->adsp;
+	struct signed_pkg_info_ext *out = &adsp->man_v1_8->signed_pkg;
 	struct signed_pkg_info_module *mod;
 	toml_array_t *bitmap_array;
 	toml_array_t *module_array;
@@ -1022,8 +1024,8 @@ static int parse_signed_pkg(const toml_table_t *toml, struct parse_ctx *pctx,
 	/* bitmap array */
 	bitmap_array = toml_array_in(signed_pkg, "bitmap");
 	if (!bitmap_array) {
-		/* default value */
-		out->bitmap[4] = 8;
+		/* default value, depending on the IMR type */
+		out->bitmap[4] = image->imr_type == 4 ? 0x10 : 0x8;
 	} else {
 		++ctx.array_cnt;
 		if (toml_array_kind(bitmap_array) != 'v' || toml_array_type(bitmap_array) != 'i' ||
@@ -1130,8 +1132,10 @@ static void dump_signed_pkg_v2_5(const struct signed_pkg_info_ext_v2_5 *signed_p
 }
 
 static int parse_signed_pkg_v2_5(const toml_table_t *toml, struct parse_ctx *pctx,
-			    struct signed_pkg_info_ext_v2_5 *out, bool verbose)
+				 struct image *image, bool verbose)
 {
+	struct adsp *adsp = image->adsp;
+	struct signed_pkg_info_ext_v2_5 *out = &adsp->man_v2_5->signed_pkg;
 	struct signed_pkg_info_module_v2_5 *mod;
 	toml_array_t *bitmap_array;
 	toml_array_t *module_array;
@@ -1178,8 +1182,8 @@ static int parse_signed_pkg_v2_5(const toml_table_t *toml, struct parse_ctx *pct
 	/* bitmap array */
 	bitmap_array = toml_array_in(signed_pkg, "bitmap");
 	if (!bitmap_array) {
-		/* default value - some use 0x10*/
-		out->bitmap[4] = 0x8;
+		/* default value, depending on the IMR type */
+		out->bitmap[4] = image->imr_type == 4 ? 0x10 : 0x8;
 	} else {
 		++ctx.array_cnt;
 		if (toml_array_kind(bitmap_array) != 'v' || toml_array_type(bitmap_array) != 'i' ||
@@ -1281,8 +1285,10 @@ static void dump_signed_pkg_ace_v1_5(const struct signed_pkg_info_ext_ace_v1_5 *
 }
 
 static int parse_signed_pkg_ace_v1_5(const toml_table_t *toml, struct parse_ctx *pctx,
-			    struct signed_pkg_info_ext_ace_v1_5 *out, bool verbose)
+				     struct image *image, bool verbose)
 {
+	struct adsp *adsp = image->adsp;
+	struct signed_pkg_info_ext_ace_v1_5 *out = &adsp->man_ace_v1_5->signed_pkg;
 	struct signed_pkg_info_module_ace_v1_5 *mod;
 	toml_array_t *module_array;
 	toml_table_t *signed_pkg;
@@ -2240,9 +2246,10 @@ static int parse_module(const toml_table_t *toml, struct parse_ctx *pctx,
 	return 0;
 }
 
-static int parse_adsp_config_v1_0(const toml_table_t *toml, struct adsp *out,
-				  bool verbose)
+static int parse_adsp_config_v1_0(const toml_table_t *toml, struct image *image)
 {
+	struct adsp *out = image->adsp;
+	bool verbose = image->verbose;
 	struct parse_ctx ctx;
 	int ret;
 
@@ -2267,9 +2274,10 @@ static int parse_adsp_config_v1_0(const toml_table_t *toml, struct adsp *out,
 	return 0;
 }
 
-static int parse_adsp_config_v1_5(const toml_table_t *toml, struct adsp *out,
-				  bool verbose)
+static int parse_adsp_config_v1_5(const toml_table_t *toml, struct image *image)
 {
+	struct adsp *out = image->adsp;
+	bool verbose = image->verbose;
 	struct parse_ctx ctx;
 	int ret;
 
@@ -2333,9 +2341,10 @@ static int parse_adsp_config_v1_5(const toml_table_t *toml, struct adsp *out,
 	return 0;
 }
 
-static int parse_adsp_config_v1_8(const toml_table_t *toml, struct adsp *out,
-				  bool verbose)
+static int parse_adsp_config_v1_8(const toml_table_t *toml, struct image *image)
 {
+	struct adsp *out = image->adsp;
+	bool verbose = image->verbose;
 	struct parse_ctx ctx;
 	int ret;
 
@@ -2370,7 +2379,7 @@ static int parse_adsp_config_v1_8(const toml_table_t *toml, struct adsp *out,
 	if (ret < 0)
 		return err_key_parse("css", NULL);
 
-	ret = parse_signed_pkg(toml, &ctx, &out->man_v1_8->signed_pkg, verbose);
+	ret = parse_signed_pkg(toml, &ctx, image, verbose);
 	if (ret < 0)
 		return err_key_parse("signed_pkg", NULL);
 
@@ -2394,9 +2403,10 @@ static int parse_adsp_config_v1_8(const toml_table_t *toml, struct adsp *out,
 	return 0;
 }
 
-static int parse_adsp_config_v2_5(const toml_table_t *toml, struct adsp *out,
-				  bool verbose)
+static int parse_adsp_config_v2_5(const toml_table_t *toml, struct image *image)
 {
+	struct adsp *out = image->adsp;
+	bool verbose = image->verbose;
 	struct parse_ctx ctx;
 	int ret;
 
@@ -2431,7 +2441,7 @@ static int parse_adsp_config_v2_5(const toml_table_t *toml, struct adsp *out,
 	if (ret < 0)
 		return err_key_parse("css", NULL);
 
-	ret = parse_signed_pkg_v2_5(toml, &ctx, &out->man_v2_5->signed_pkg, verbose);
+	ret = parse_signed_pkg_v2_5(toml, &ctx, image, verbose);
 	if (ret < 0)
 		return err_key_parse("signed_pkg", NULL);
 
@@ -2459,9 +2469,10 @@ static int parse_adsp_config_v2_5(const toml_table_t *toml, struct adsp *out,
 	return 0;
 }
 
-static int parse_adsp_config_ace_v1_5(const toml_table_t *toml, struct adsp *out,
-				  bool verbose)
+static int parse_adsp_config_ace_v1_5(const toml_table_t *toml, struct image *image)
 {
+	struct adsp *out = image->adsp;
+	bool verbose = image->verbose;
 	struct parse_ctx ctx;
 	int ret;
 
@@ -2495,7 +2506,7 @@ static int parse_adsp_config_ace_v1_5(const toml_table_t *toml, struct adsp *out
 	if (ret < 0)
 		return err_key_parse("css", NULL);
 
-	ret = parse_signed_pkg_ace_v1_5(toml, &ctx, &out->man_ace_v1_5->signed_pkg, verbose);
+	ret = parse_signed_pkg_ace_v1_5(toml, &ctx, image, verbose);
 	if (ret < 0)
 		return err_key_parse("signed_pkg", NULL);
 
@@ -2556,7 +2567,7 @@ static int parse_version(toml_table_t *toml, int64_t version[2])
 struct config_parser {
 	int major;
 	int minor;
-	int (*parse)(const toml_table_t *toml, struct adsp *out, bool verbose);
+	int (*parse)(const toml_table_t *toml, struct image *image);
 };
 
 static const struct config_parser *find_config_parser(int64_t version[2])
@@ -2580,7 +2591,7 @@ static const struct config_parser *find_config_parser(int64_t version[2])
 	return NULL;
 }
 
-static int adsp_parse_config_fd(FILE *fd, struct adsp *out, bool verbose)
+static int adsp_parse_config_fd(FILE *fd, struct image *image)
 {
 	const struct config_parser *parser;
 	int64_t manifest_version[2];
@@ -2607,14 +2618,14 @@ static int adsp_parse_config_fd(FILE *fd, struct adsp *out, bool verbose)
 	}
 
 	/* run dedicated parser */
-	ret = parser->parse(toml, out, verbose);
+	ret = parser->parse(toml, image);
 error:
 	toml_free(toml);
 	return ret;
 }
 
 /* public function, fully handle parsing process */
-int adsp_parse_config(const char *file, struct adsp *out, bool verbose)
+int adsp_parse_config(const char *file, struct image *image)
 {
 	FILE *fd;
 	int ret;
@@ -2622,7 +2633,7 @@ int adsp_parse_config(const char *file, struct adsp *out, bool verbose)
 	fd = fopen(file, "r");
 	if (!fd)
 		return log_err(-EIO, "error: can't open '%s' file\n", file);
-	ret = adsp_parse_config_fd(fd, out, verbose);
+	ret = adsp_parse_config_fd(fd, image);
 	fclose(fd);
 	return ret;
 }

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -1579,7 +1579,8 @@ static int parse_adsp_file_ext_v1_8(const toml_table_t *toml, struct parse_ctx *
 	out->ext_len = sizeof(struct sof_man_adsp_meta_file_ext_v1_8);
 
 	/* configurable fields */
-	out->imr_type = parse_uint32_hex_key(adsp_file_ext, &ctx, "imr_type", 0, &ret);
+	out->imr_type = parse_uint32_hex_key(adsp_file_ext, &ctx, "imr_type",
+					     MAN_DEFAULT_IMR_TYPE, &ret);
 	if (ret < 0)
 		return ret;
 
@@ -1699,7 +1700,8 @@ static int parse_adsp_file_ext_v2_5(const toml_table_t *toml, struct parse_ctx *
 	out->ext_len = sizeof(struct sof_man_adsp_meta_file_ext_v2_5);
 
 	/* configurable fields */
-	out->imr_type = parse_uint32_hex_key(adsp_file_ext, &ctx, "imr_type", 0, &ret);
+	out->imr_type = parse_uint32_hex_key(adsp_file_ext, &ctx, "imr_type",
+					     MAN_DEFAULT_IMR_TYPE, &ret);
 	if (ret < 0)
 		return ret;
 

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -929,7 +929,6 @@ static int parse_css_v2_5(const toml_table_t *toml, struct parse_ctx *pctx,
 		return ret;
 
 	/* hardcoded to align with meu */
-	out->reserved0 = 0;
 	out->reserved1[0] = 0xf;
 	out->reserved1[1] = 0x048e0000; // TODO: what is this ?
 

--- a/src/include/rimage/adsp_config.h
+++ b/src/include/rimage/adsp_config.h
@@ -5,5 +5,5 @@
 #include <rimage/rimage.h>
 #include <stdbool.h>
 
-int adsp_parse_config(const char *file, struct adsp *out, bool verbose);
+int adsp_parse_config(const char *file, struct image *image);
 void adsp_free(struct adsp *adsp);

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -77,7 +77,7 @@ struct image {
 	FILE *out_fd;
 	void *pos;
 
-	const struct adsp *adsp;
+	struct adsp *adsp;
 	int abi;
 	int verbose;
 	int reloc;	/* ELF data is relocatable */
@@ -111,6 +111,8 @@ struct image {
 	uint16_t fw_ver_minor;
 	uint16_t fw_ver_micro;
 	uint16_t fw_ver_build;
+
+	uint32_t imr_type;
 };
 
 struct mem_zone {

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -40,12 +40,13 @@ int main(int argc, char *argv[])
 	struct adsp *heap_adsp;
 	const char *adsp_config = NULL;
 	int opt, ret, i, first_non_opt;
-	int imr_type = MAN_DEFAULT_IMR_TYPE;
 	int use_ext_man = 0;
 	unsigned int pv_bit = 0;
 	bool imr_type_override = false;
 
 	memset(&image, 0, sizeof(image));
+
+	image.imr_type = MAN_DEFAULT_IMR_TYPE;
 
 	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:p")) != -1) {
 		switch (opt) {
@@ -68,7 +69,7 @@ int main(int argc, char *argv[])
 			image.reloc = 1;
 			break;
 		case 'i':
-			imr_type = atoi(optarg);
+			image.imr_type = atoi(optarg);
 			imr_type_override = true;
 			break;
 		case 'f':
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
 	}
 	image.adsp = heap_adsp;
 	memset(heap_adsp, 0, sizeof(*heap_adsp));
-	ret = adsp_parse_config(adsp_config, heap_adsp, image.verbose);
+	ret = adsp_parse_config(adsp_config, &image);
 	if (ret < 0)
 		goto out;
 
@@ -173,19 +174,19 @@ int main(int argc, char *argv[])
 	/* set IMR Type and the PV bit in found machine definition */
 	if (image.adsp->man_v1_8) {
 		if (imr_type_override)
-			image.adsp->man_v1_8->adsp_file_ext.imr_type = imr_type;
+			image.adsp->man_v1_8->adsp_file_ext.imr_type = image.imr_type;
 		image.adsp->man_v1_8->css.reserved0 = pv_bit;
 	}
 
 	if (image.adsp->man_v2_5) {
 		if (imr_type_override)
-			image.adsp->man_v2_5->adsp_file_ext.imr_type = imr_type;
+			image.adsp->man_v2_5->adsp_file_ext.imr_type = image.imr_type;
 		image.adsp->man_v2_5->css.reserved0 = pv_bit;
 	}
 
 	if (image.adsp->man_ace_v1_5) {
 		if (imr_type_override)
-			image.adsp->man_ace_v1_5->adsp_file_ext.imr_type = imr_type;
+			image.adsp->man_ace_v1_5->adsp_file_ext.imr_type = image.imr_type;
 		image.adsp->man_ace_v1_5->css.reserved0 = pv_bit;
 	}
 

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -31,6 +31,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -e build extended manifest\n");
 	fprintf(stdout, "\t -y verify signed file\n");
 	fprintf(stdout, "\t -q resign binary\n");
+	fprintf(stdout, "\t -p set PV bit\n");
 }
 
 int main(int argc, char *argv[])
@@ -41,10 +42,11 @@ int main(int argc, char *argv[])
 	int opt, ret, i, first_non_opt;
 	int imr_type = MAN_DEFAULT_IMR_TYPE;
 	int use_ext_man = 0;
+	unsigned int pv_bit = 0;
 
 	memset(&image, 0, sizeof(image));
 
-	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:p")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;
@@ -87,6 +89,9 @@ int main(int argc, char *argv[])
 			return 0;
 		case 'q':
 			image.in_file = optarg;
+			break;
+		case 'p':
+			pv_bit = 1;
 			break;
 		default:
 		 /* getopt's default error message is good enough */
@@ -163,15 +168,21 @@ int main(int argc, char *argv[])
 		return resign_image(&image);
 	}
 
-	/* set IMR Type in found machine definition */
-	if (image.adsp->man_v1_8)
+	/* set IMR Type and the PV bit in found machine definition */
+	if (image.adsp->man_v1_8) {
 		image.adsp->man_v1_8->adsp_file_ext.imr_type = imr_type;
+		image.adsp->man_v1_8->css.reserved0 = pv_bit;
+	}
 
-	if (image.adsp->man_v2_5)
+	if (image.adsp->man_v2_5) {
 		image.adsp->man_v2_5->adsp_file_ext.imr_type = imr_type;
+		image.adsp->man_v2_5->css.reserved0 = pv_bit;
+	}
 
-	if (image.adsp->man_ace_v1_5)
+	if (image.adsp->man_ace_v1_5) {
 		image.adsp->man_ace_v1_5->adsp_file_ext.imr_type = imr_type;
+		image.adsp->man_ace_v1_5->css.reserved0 = pv_bit;
+	}
 
 	/* parse input ELF files */
 	image.num_modules = argc - first_non_opt;

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
 	int imr_type = MAN_DEFAULT_IMR_TYPE;
 	int use_ext_man = 0;
 	unsigned int pv_bit = 0;
+	bool imr_type_override = false;
 
 	memset(&image, 0, sizeof(image));
 
@@ -68,6 +69,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'i':
 			imr_type = atoi(optarg);
+			imr_type_override = true;
 			break;
 		case 'f':
 			image.fw_ver_string = optarg;
@@ -170,17 +172,20 @@ int main(int argc, char *argv[])
 
 	/* set IMR Type and the PV bit in found machine definition */
 	if (image.adsp->man_v1_8) {
-		image.adsp->man_v1_8->adsp_file_ext.imr_type = imr_type;
+		if (imr_type_override)
+			image.adsp->man_v1_8->adsp_file_ext.imr_type = imr_type;
 		image.adsp->man_v1_8->css.reserved0 = pv_bit;
 	}
 
 	if (image.adsp->man_v2_5) {
-		image.adsp->man_v2_5->adsp_file_ext.imr_type = imr_type;
+		if (imr_type_override)
+			image.adsp->man_v2_5->adsp_file_ext.imr_type = imr_type;
 		image.adsp->man_v2_5->css.reserved0 = pv_bit;
 	}
 
 	if (image.adsp->man_ace_v1_5) {
-		image.adsp->man_ace_v1_5->adsp_file_ext.imr_type = imr_type;
+		if (imr_type_override)
+			image.adsp->man_ace_v1_5->adsp_file_ext.imr_type = imr_type;
 		image.adsp->man_ace_v1_5->css.reserved0 = pv_bit;
 	}
 


### PR DESCRIPTION
Add a '-p' command line flag to set Intel reserved bit in IMR area.

Inspired by #113 but unfortunately this is urgent and has to be done with a command line switch, so I had to guess what this should do.