### PR TITLE
Convert all ELF addresses to cached for calculations

### DIFF
--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x2F0000"
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -20,6 +21,13 @@ size = "0x800000"
 type = "LP-SRAM"
 base = "0xBE800000"
 size = "0x40"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/src/elf.c
+++ b/src/elf.c
@@ -12,6 +12,11 @@
 #include <rimage/cse.h>
 #include <rimage/manifest.h>
 
+static unsigned long uncache_to_cache(const struct image *image, unsigned long address)
+{
+	return ((address & ~image->adsp->alias_mask) | image->adsp->alias_cached);
+}
+
 static int elf_read_sections(struct image *image, struct module *module,
 			     int module_index)
 {
@@ -110,6 +115,7 @@ static int elf_read_sections(struct image *image, struct module *module,
 			continue;
 		}
 
+		section[i].vaddr = uncache_to_cache(image, section[i].vaddr);
 		module->num_sections++;
 
 		if (!image->verbose)
@@ -367,8 +373,8 @@ static void elf_module_limits(struct image *image, struct module *module)
 		/* check programs to get LMA */
 		section_lma = section->vaddr;
 		for (j = 0; j < module->hdr.phnum; j++) {
-			if (section->vaddr == module->prg[j].vaddr) {
-				section_lma = module->prg[j].paddr;
+			if (section->vaddr == uncache_to_cache(image, module->prg[j].vaddr)) {
+				section_lma = uncache_to_cache(image, module->prg[j].paddr);
 				break;
 			}
 		}

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -153,6 +153,10 @@ struct adsp {
 	uint32_t image_size;
 	uint32_t dram_offset;
 
+	uint32_t alias_cached;
+	uint32_t alias_uncached;
+	uint32_t alias_mask;
+
 	int (*write_firmware_ext_man)(struct image *image);
 	int (*write_firmware)(struct image *image);
 	int (*write_firmware_meu)(struct image *image);


### PR DESCRIPTION
Rimage calculates sizes of ELF sections, for which it has to use addresses from the same address space: either all cached or all uncached. The ELF image itself can contain mixed addresses. Convert all to cached for internal calculations.