### PR TITLE
Add Init config type for modules

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -402,6 +402,7 @@ count = 16
 	instance_count = "1"
 	domain_types = "0"
 	load_type = "0"
+	init_config = "1"
 	module_type = "13"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]

--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -276,6 +276,7 @@ count = 12
 	domain_types = "0"
 	load_type = "0"
 	module_type = "13"
+	init_config = "1"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -2193,6 +2193,11 @@ static int parse_module(const toml_table_t *toml, struct parse_ctx *pctx,
 		if (ret < 0)
 			return err_key_parse("load_type", NULL);
 
+		mod_man->type.init_config = parse_uint32_hex_key(mod_entry, &ctx_entry,
+								"init_config", 1, &ret);
+		if (ret < 0)
+			return err_key_parse("init_config", NULL);
+
 		mod_man->type.auto_start = parse_uint32_hex_key(mod_entry, &ctx_entry,
 								"auto_start", 1, &ret);
 		if (ret < 0)

--- a/src/include/rimage/sof/user/manifest.h
+++ b/src/include/rimage/sof/user/manifest.h
@@ -26,13 +26,18 @@
 #define SOF_MAN_MOD_TYPE_BUILTIN	0
 #define SOF_MAN_MOD_TYPE_MODULE		1
 
+/* module init config */
+#define SOF_MAN_MOD_INIT_CONFIG_BASE_CFG               0 /* Base config only */
+#define SOF_MAN_MOD_INIT_CONFIG_BASE_CFG_WITH_EXT      1 /* Base config with extension */
+
 struct sof_man_module_type {
 	uint32_t load_type:4;	/* SOF_MAN_MOD_TYPE_ */
 	uint32_t auto_start:1;
 	uint32_t domain_ll:1;
 	uint32_t domain_dp:1;
 	uint32_t lib_code:1;
-	uint32_t rsvd_:24;
+	uint32_t init_config:4; /* SOF_MAN_MOD_INIT_CONFIG_ */
+	uint32_t rsvd_:20;
 };
 
 /* segment flags.type */


### PR DESCRIPTION
USe some reverved bits to add the init config information for modules that will be used to indicate whether the base config extension needs to be added to the init module payload or not.