### PR TITLE
Fix regression - make default return code an error

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -3,6 +3,7 @@ version = [3, 0]
 [adsp]
 name = "mtl"
 image_size = "0x2C0000" # (22) bank * 128KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x2000"
 type = "SRAM"
 base = "0xa00f0000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x40000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xA0000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/tgl-h-cavs.toml
+++ b/config/tgl-h-cavs.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x1F0000" # (30 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -20,6 +21,13 @@ size = "0x800000"
 type = "LP-SRAM"
 base = "0xBE800000"
 size = "0x40"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x1F0000" # (30 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x2F0000" # (46 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -404,7 +404,7 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 	if (ret < 0)
 		return ret;
 
-	out->alias_mask = parse_uint32_hex_key(adsp, &ctx, "alias_mask", 0, &ret);
+	out->alias_mask = parse_uint32_hex_key(adsp, &ctx, "alias_mask", -ENODATA, &ret);
 	alias_found = !ret;
 
 	/* check everything parsed, 1 or 2 tables should be present */


### PR DESCRIPTION
A recent commit ec649f37d661 ("Convert all ELF addresses to cached for calculations") had a bug: it assumed a call to parse_uint32_hex_key() for an absent key would return an error by default, which isn't the case. To force it set the default return code to an error value.