### PR TITLE
config:tgl/tglh: Do not set cached/uncached address aliases

### DIFF
--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -3,7 +3,6 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x1F0000" # (30 + 1) bank * 64KB
-alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -17,13 +16,6 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
-
-[[adsp.mem_alias]]
-type = "uncached"
-base = "0x9E000000"
-[[adsp.mem_alias]]
-type = "cached"
-base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -3,7 +3,6 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x2F0000" # (46 + 1) bank * 64KB
-alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -17,13 +16,6 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
-
-[[adsp.mem_alias]]
-type = "uncached"
-base = "0x9E000000"
-[[adsp.mem_alias]]
-type = "cached"
-base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"


### PR DESCRIPTION
tgl.toml and tgl-h.toml are only used for xtos builds.

Suggested-by: Guennadi Liakhovetski <guennadi.liakhovetski@linux.intel.com>
Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>