### PR TITLE
config: mtl: set init_config for micsel

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -296,6 +296,7 @@ count = 16
 	instance_count = "8"
 	domain_types = "0"
 	load_type = "0"
+	init_config = "1"
 	module_type = "12"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]


### PR DESCRIPTION
The micsel module will use base config extension,
init_config should be one for it.