### PR TITLE
main: heap_adsp release fix

### DIFF
--- a/src/rimage.c
+++ b/src/rimage.c
@@ -168,7 +168,8 @@ int main(int argc, char *argv[])
 
 	if (image.in_file) {
 		fprintf(stdout, "going to re-sign\n");
-		return resign_image(&image);
+		ret = resign_image(&image);
+		goto out;
 	}
 
 	/* set IMR Type and the PV bit in found machine definition */
@@ -196,7 +197,8 @@ int main(int argc, char *argv[])
 	if (image.num_modules <= 0) {
 		fprintf(stderr,
 			"error: requires at least one ELF input module\n");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out;
 	}
 
 	/* getopt reorders argv[] */


### PR DESCRIPTION
In image re-signing mode or if there are no input files, the memory allocated for heap_adsp was not released.