### PR TITLE
file_utils: manifest: elf: Separation of the code fragments to the new functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(rimage
 	src/elf.c
 	src/rimage.c
 	src/adsp_config.c
+	src/file_utils.c
 	tomlc99/toml.c
 )
 

--- a/src/elf.c
+++ b/src/elf.c
@@ -11,6 +11,7 @@
 #include <rimage/rimage.h>
 #include <rimage/cse.h>
 #include <rimage/manifest.h>
+#include <rimage/file_utils.h>
 
 static unsigned long uncache_to_cache(const struct image *image, unsigned long address)
 {
@@ -604,11 +605,7 @@ int elf_parse_module(struct image *image, int module_index, const char *name)
 	module->elf_file = name;
 
 	/* get file size */
-	ret = fseek(module->fd, 0, SEEK_END);
-	if (ret < 0)
-		goto hdr_err;
-	module->file_size = ftell(module->fd);
-	ret = fseek(module->fd, 0, SEEK_SET);
+	ret = get_file_size(module->fd, name, &module->file_size);
 	if (ret < 0)
 		goto hdr_err;
 

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -14,6 +14,7 @@
 #include <rimage/rimage.h>
 #include <rimage/cavs/cavs_ext_manifest.h>
 #include <rimage/manifest.h>
+#include <rimage/file_utils.h>
 
 const struct ext_man_header ext_man_template = {
 	.magic = EXT_MAN_MAGIC_NUMBER,
@@ -24,10 +25,14 @@ const struct ext_man_header ext_man_template = {
 
 static int ext_man_open_file(struct image *image)
 {
-	/* open extended manifest outfile for writing */
-	sprintf(image->out_ext_man_file, "%s.xman", image->out_file);
-	unlink(image->out_ext_man_file);
+	int ret;
 
+	ret = create_file_name(image->out_ext_man_file, sizeof(image->out_ext_man_file),
+			       image->out_file, "xman");
+	if (ret)
+		return ret;
+
+	/* open extended manifest outfile for writing */
 	image->out_ext_man_fd = fopen(image->out_ext_man_file, "wb");
 	if (!image->out_ext_man_fd) {
 		fprintf(stderr, "error: unable to open %s for writing %d\n",

--- a/src/file_simple.c
+++ b/src/file_simple.c
@@ -229,7 +229,7 @@ static int write_block_reloc(struct image *image, struct module *module)
 		goto out;
 	}
 
-	fprintf(stdout, "\t%d\t0x%8.8x\t0x%8.8x\t0x%8.8lx\t%s\n", block_idx++,
+	fprintf(stdout, "\t%d\t0x%8.8x\t0x%8.8zx\t0x%8.8lx\t%s\n", block_idx++,
 		0, module->file_size, ftell(image->out_fd),
 		block.type == SOF_FW_BLK_TYPE_IRAM ? "TEXT" : "DATA");
 

--- a/src/file_utils.c
+++ b/src/file_utils.c
@@ -36,3 +36,38 @@ int create_file_name(char *new_name, const size_t name_size, const char *templat
 
 	return 0;
 }
+
+/**
+ * Get file size
+ * @param [in] f file handle
+ * @param [in] filename File name used to display the error message
+ * @param [out] size output for file size
+ * @param error code, 0 when success
+ */
+int get_file_size(FILE *f, const char* filename, size_t *size)
+{
+	int ret;
+
+	assert(size);
+
+	/* get file size */
+	ret = fseek(f, 0, SEEK_END);
+	if (ret < 0) {
+		fprintf(stderr, "error: unable to seek eof %s %d\n", filename, errno);
+		return -errno;
+	}
+
+	*size = ftell(f);
+	if (*size < 0) {
+		fprintf(stderr, "error: unable to get file size for %s %d\n", filename, errno);
+		return -errno;
+	}
+
+	ret = fseek(f, 0, SEEK_SET);
+	if (ret < 0) {
+		fprintf(stderr, "error: unable to seek set %s %d\n", filename, errno);
+		return -errno;
+	}
+
+	return 0;
+}

--- a/src/file_utils.c
+++ b/src/file_utils.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2018-2023 Intel Corporation. All rights reserved.
+//
+// Author: Adrian Warecki <adrian.warecki@intel.com>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <assert.h>
+
+#include <rimage/file_utils.h>
+
+/**
+ * Create new file name using output file name as template.
+ * @param [out] new_name char[] destination of new file name
+ * @param [in] name_size new file name buffer capacity
+ * @param [in] template_name File name used as a template for the new name
+ * @param [in] new_ext extension of the new file name
+ * @param error code, 0 when success
+ */
+int create_file_name(char *new_name, const size_t name_size, const char *template_name,
+		   const char *new_ext)
+{
+	int len;
+
+	assert(new_name);
+
+	len = snprintf(new_name, name_size, "%s.%s", template_name, new_ext);
+	if (len >= name_size) {
+		fprintf(stderr, "error: output file name too long\n");
+		return -ENAMETOOLONG;
+	}
+
+	unlink(new_name);
+
+	return 0;
+}

--- a/src/include/rimage/file_utils.h
+++ b/src/include/rimage/file_utils.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __FILE_UTILS_H__
+#define __FILE_UTILS_H__
+
+#include <stddef.h>
+
+/**
+ * Create new file name using output file name as template.
+ * @param [out] new_name char[] destination of new file name
+ * @param [in] name_size new file name buffer capacity
+ * @param [in] template_name File name used as a template for the new name
+ * @param [in] new_ext extension of the new file name
+ * @param error code, 0 when success
+ */
+int create_file_name(char *new_name, const size_t name_size, const char *template_name,
+		     const char *new_ext);
+
+#endif /* __FILE_UTILS_H__ */

--- a/src/include/rimage/file_utils.h
+++ b/src/include/rimage/file_utils.h
@@ -19,4 +19,13 @@
 int create_file_name(char *new_name, const size_t name_size, const char *template_name,
 		     const char *new_ext);
 
+/**
+ * Get file size
+ * @param [in] f file handle
+ * @param [in] filename File name used to display the error message
+ * @param [out] size output for file size
+ * @param error code, 0 when success
+ */
+int get_file_size(FILE *f, const char *filename, size_t *size);
+
 #endif /* __FILE_UTILS_H__ */

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -61,7 +61,7 @@ struct module {
 	int data_file_size;
 
 	/* total file size */
-	int file_size;
+	size_t file_size;
 
 	/* executable header module */
 	int exec_header;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -585,7 +585,7 @@ static int man_module_create_reloc(struct image *image, struct module *module,
 		return -errno;
 	}
 
-	fprintf(stdout, "\t%d\t0x%8.8x\t0x%8.8x\t0x%x\t%s\n", 0,
+	fprintf(stdout, "\t%d\t0x%8.8x\t0x%8.8zx\t0x%x\t%s\n", 0,
 		0, module->file_size, 0, "DATA");
 
 	fprintf(stdout, "\n");

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -22,13 +22,17 @@
 #include <rimage/cse.h>
 #include <rimage/plat_auth.h>
 #include <rimage/manifest.h>
+#include <rimage/file_utils.h>
 
 static int man_open_rom_file(struct image *image)
 {
 	uint32_t size;
+	int ret;
 
-	sprintf(image->out_rom_file, "%s.rom", image->out_file);
-	unlink(image->out_rom_file);
+	ret = create_file_name(image->out_rom_file, sizeof(image->out_rom_file), image->out_file,
+			       "rom");
+	if (ret)
+		return ret;
 
 	size = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].size;
 
@@ -50,8 +54,12 @@ static int man_open_rom_file(struct image *image)
 
 static int man_open_unsigned_file(struct image *image)
 {
-	sprintf(image->out_unsigned_file, "%s.uns", image->out_file);
-	unlink(image->out_unsigned_file);
+	int ret;
+
+	ret = create_file_name(image->out_unsigned_file, sizeof(image->out_unsigned_file),
+			       image->out_file, "uns");
+	if (ret)
+		return ret;
 
 	/* open unsigned FW outfile for writing */
 	image->out_unsigned_fd = fopen(image->out_unsigned_file, "wb");
@@ -66,10 +74,14 @@ static int man_open_unsigned_file(struct image *image)
 
 static int man_open_manifest_file(struct image *image)
 {
-	/* open manifest outfile for writing */
-	sprintf(image->out_man_file, "%s.met", image->out_file);
-	unlink(image->out_man_file);
+	int ret;
 
+	ret = create_file_name(image->out_man_file, sizeof(image->out_man_file), image->out_file,
+			       "met");
+	if (ret)
+		return ret;
+
+	/* open manifest outfile for writing */
 	image->out_man_fd = fopen(image->out_man_file, "wb");
 	if (!image->out_man_fd) {
 		fprintf(stderr, "error: unable to open %s for writing %d\n",

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1516,10 +1516,9 @@ err:
 int verify_image(struct image *image)
 {
 	FILE *in_file;
-	int ret, i;
-	long size;
+	int ret;
 	void *buffer;
-	size_t read;
+	size_t size, read, i;
 
 	/* is verify supported for target ? */
 	if (!image->adsp->verify_firmware) {
@@ -1536,25 +1535,8 @@ int verify_image(struct image *image)
 	}
 
 	/* get file size */
-	ret = fseek(in_file, 0, SEEK_END);
+	ret = get_file_size(in_file, image->verify_file, &size);
 	if (ret < 0) {
-		fprintf(stderr, "error: unable to seek eof %s for reading %d\n",
-			image->verify_file, errno);
-		ret = -errno;
-		goto out;
-	}
-	size = ftell(in_file);
-	if (size < 0) {
-		fprintf(stderr, "error: unable to get file size for %s %d\n",
-			image->verify_file, errno);
-		ret = -errno;
-		goto out;
-	}
-	ret = fseek(in_file, 0, SEEK_SET);
-	if (ret < 0) {
-		fprintf(stderr, "error: unable to seek %s for reading %d\n",
-			image->verify_file, errno);
-		ret = -errno;
 		goto out;
 	}
 
@@ -1608,27 +1590,8 @@ int resign_image(struct image *image)
 	}
 
 	/* get file size */
-	ret = fseek(in_file, 0, SEEK_END);
+	ret = get_file_size(in_file, image->in_file, &size);
 	if (ret < 0) {
-		fprintf(stderr, "error: unable to seek eof %s for reading %d\n",
-			image->verify_file, errno);
-		ret = -errno;
-		goto out;
-	}
-
-	size = ftell(in_file);
-	if (size < 0) {
-		fprintf(stderr, "error: unable to get file size for %s %d\n",
-			image->verify_file, errno);
-		ret = -errno;
-		goto out;
-	}
-
-	ret = fseek(in_file, 0, SEEK_SET);
-	if (ret < 0) {
-		fprintf(stderr, "error: unable to seek %s for reading %d\n",
-			image->verify_file, errno);
-		ret = -errno;
 		goto out;
 	}
 


### PR DESCRIPTION
A new function create_file_name has been created that prepares the name of the output file with the given extensions. Unlike the previous solution, it checks whether the new name will fit in the output buffer.

A new file_utils.c file has been prepared, into which generic functions to simplify the use of files will be moved.

Added a new get_file_size function which allows to conveniently get the size of the file.
Simplified retrieval of file size by using the function get_file_size in manifest and elf.