### PR TITLE
mtl: add Aria module to extended manifest

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -57,7 +57,7 @@ name = "ADSPFW"
 load_offset = "0x40000"
 
 [module]
-count = 18
+count = 19
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
@@ -459,5 +459,30 @@ count = 18
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 		1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
 
-# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+	
+	# Aria module config
+	[[module.entry]]
+	name = "ARIA"
+	uuid = "99F7166D-372C-43EF-81F6-22007AA15F03"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	init_config = "1"
+	module_type = "30"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 260, 1063000, 16, 21, 0, 0, 0,
+				1, 0, 0, 0, 260, 1873500, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 260, 2680000, 32, 42, 0, 0, 0,
+				3, 0, 0, 0, 260, 3591000, 64, 85, 0, 0, 0,
+				4, 0, 0, 0, 260, 4477000, 96, 128, 0, 0, 0,
+				5, 0, 0, 0, 260, 7195000, 192, 192, 0, 0, 0]


### PR DESCRIPTION
Add ARIA module to MTL extended manifest.