### PR TITLE
file_utils: Add file_error function

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -15,6 +15,7 @@
 #include "rimage/cse.h"
 #include "rimage/css.h"
 #include "rimage/toml_utils.h"
+#include "rimage/file_utils.h"
 #include "toml.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -2348,7 +2349,8 @@ int adsp_parse_config(const char *file, struct image *image)
 
 	fd = fopen(file, "r");
 	if (!fd)
-		return log_err(-EIO, "error: can't open '%s' file\n", file);
+		return file_error("unable to open file for reading", file);
+
 	ret = adsp_parse_config_fd(fd, image);
 	fclose(fd);
 	return ret;

--- a/src/file_utils.c
+++ b/src/file_utils.c
@@ -44,7 +44,7 @@ int create_file_name(char *new_name, const size_t name_size, const char *templat
 int get_file_size(FILE *f, const char* filename, size_t *size)
 {
 	int ret;
-
+	long pos;
 	assert(size);
 
 	/* get file size */
@@ -52,13 +52,14 @@ int get_file_size(FILE *f, const char* filename, size_t *size)
 	if (ret)
 		return file_error("unable to seek eof", filename);
 
-	*size = ftell(f);
-	if (*size < 0)
+	pos = ftell(f);
+	if (pos < 0)
 		return file_error("unable to get file size", filename);
 
 	ret = fseek(f, 0, SEEK_SET);
 	if (ret)
 		return file_error("unable to seek set", filename);
 
+	*size = pos;
 	return 0;
 }

--- a/src/file_utils.c
+++ b/src/file_utils.c
@@ -11,14 +11,6 @@
 
 #include <rimage/file_utils.h>
 
-/**
- * Create new file name using output file name as template.
- * @param [out] new_name char[] destination of new file name
- * @param [in] name_size new file name buffer capacity
- * @param [in] template_name File name used as a template for the new name
- * @param [in] new_ext extension of the new file name
- * @param error code, 0 when success
- */
 int create_file_name(char *new_name, const size_t name_size, const char *template_name,
 		   const char *new_ext)
 {
@@ -37,13 +29,6 @@ int create_file_name(char *new_name, const size_t name_size, const char *templat
 	return 0;
 }
 
-/**
- * Get file size
- * @param [in] f file handle
- * @param [in] filename File name used to display the error message
- * @param [out] size output for file size
- * @param error code, 0 when success
- */
 int get_file_size(FILE *f, const char* filename, size_t *size)
 {
 	int ret;

--- a/src/include/rimage/file_utils.h
+++ b/src/include/rimage/file_utils.h
@@ -9,6 +9,14 @@
 #include <stddef.h>
 
 /**
+ * Print file operation error message
+ * @param [in]msg error message
+ * @param [in]filename File name used to display the error message
+ * @param error code
+ */
+int file_error(const char *msg, const char *filename);
+
+/**
  * Create new file name using output file name as template.
  * @param [out] new_name char[] destination of new file name
  * @param [in] name_size new file name buffer capacity

--- a/src/pkcs1_5.c
+++ b/src/pkcs1_5.c
@@ -24,6 +24,7 @@
 #include <rimage/css.h>
 #include <rimage/manifest.h>
 #include <rimage/misc_utils.h>
+#include <rimage/file_utils.h>
 #include <rimage/hash.h>
 
 #define DEBUG_PKCS	0
@@ -57,11 +58,9 @@ static int rimage_read_key(EVP_PKEY **privkey, struct image *image)
 
 	fprintf(stdout, " %s: read key '%s'\n", __func__, path);
 	fp = fopen(path, "rb");
-	if (!fp) {
-		fprintf(stderr, "error: can't open file %s %d\n",
-			path, -errno);
-		return -errno;
-	}
+	if (!fp)
+		return file_error("unable to open file for reading", path);
+	
 	PEM_read_PrivateKey(fp, privkey, NULL, NULL);
 	fclose(fp);
 

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -14,6 +14,7 @@
 #include <rimage/ext_manifest_gen.h>
 #include <rimage/rimage.h>
 #include <rimage/manifest.h>
+#include <rimage/file_utils.h>
 
 
 static void usage(char *name)
@@ -218,9 +219,7 @@ int main(int argc, char *argv[])
 	unlink(image.out_file);
 	image.out_fd = fopen(image.out_file, "wb");
 	if (!image.out_fd) {
-		fprintf(stderr, "error: unable to open %s for writing %d\n",
-			image.out_file, errno);
-		ret = -EINVAL;
+		ret = file_error("unable to open file for writing", image.out_file);
 		goto out;
 	}
 


### PR DESCRIPTION
Added a generic function that displays a file operation error message.
Removed duplicated function descriptions - functions are already described in the header file.
Use file_error function to print file related errors.
Fixed minor issues.