### PR TITLE
Fix Zephyr IPC3 builds

### DIFF
--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x1F0000" # (30 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x2F0000" # (46 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -2334,6 +2334,8 @@ static int adsp_parse_config_fd(FILE *fd, struct image *image)
 		goto error;
 	}
 
+	image->adsp->image_rtos = RTOS_ZEPHYR;
+
 	/* run dedicated toml configuration parser */
 	ret = parser->parse(toml, image);
 error:

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -138,6 +138,11 @@ struct fw_image_manifest_module {
 	struct sof_man_module *mod_man;
 };
 
+enum rtos_variant {
+	RTOS_XTOS,
+	RTOS_ZEPHYR,
+};
+
 /*
  * Audio DSP descriptor and operations.
  */
@@ -146,6 +151,7 @@ struct adsp {
 	struct mem_zone mem_zones[SOF_FW_BLK_TYPE_NUM];
 
 	uint32_t image_size;
+	enum rtos_variant image_rtos;
 	uint32_t dram_offset;
 
 	uint32_t alias_cached;


### PR DESCRIPTION
Zephyr IPC3 builds use the same TOML files as XTOS builds, therefore those files should contain alias specifiers.