### PR TITLE
Revert "config:tgl/tglh: Do not set cached/uncached address aliases"

### DIFF
--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x1F0000" # (30 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -3,6 +3,7 @@ version = [2, 5]
 [adsp]
 name = "tgl"
 image_size = "0x2F0000" # (46 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"


### PR DESCRIPTION
Now that rimage can distinguish between Zephyr and XTOS builds, we can use memory alias specifiers with both.

This reverts commit 1e0a85b44a19db37f9dd18906091d87abd8bd5e6.