### PR TITLE
cAVS: add alias definitions to cAVS 1.5-2.0

### DIFF
--- a/config/apl.toml
+++ b/config/apl.toml
@@ -3,6 +3,7 @@ version = [1, 8]
 [adsp]
 name = "apl"
 image_size = "0x0A0000"        # (8 + 2) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -12,6 +13,13 @@ size = "0x00002000"
 type = "SRAM"
 base = "0xA000A000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/cnl.toml
+++ b/config/cnl.toml
@@ -3,6 +3,7 @@ version = [1, 8]
 [adsp]
 name = "cnl"
 image_size = "0x300000"	# (47 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/icl.toml
+++ b/config/icl.toml
@@ -3,6 +3,7 @@ version = [1, 8]
 [adsp]
 name = "icl"
 image_size = "0x300000"	# (47 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/jsl.toml
+++ b/config/jsl.toml
@@ -3,6 +3,7 @@ version = [1, 8]
 [adsp]
 name = "icl"
 image_size = "0x110000"	# (16 + 1) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -16,6 +17,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xBE040000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [cse]
 partition_name = "ADSP"

--- a/config/kbl.toml
+++ b/config/kbl.toml
@@ -3,6 +3,7 @@ version = [1, 5]
 [adsp]
 name = "kbl"
 image_size = "0x200000" # (30 + 2) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -12,6 +13,13 @@ size = "0x00002000"
 type = "SRAM"
 base = "0xA000A000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [css]
 

--- a/config/skl.toml
+++ b/config/skl.toml
@@ -3,6 +3,7 @@ version = [1, 5]
 [adsp]
 name = "skl"
 image_size = "0x200000" # (30 + 2) bank * 64KB
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -12,6 +13,13 @@ size = "0x00002000"
 type = "SRAM"
 base = "0xA000A000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [css]
 

--- a/config/sue.toml
+++ b/config/sue.toml
@@ -4,6 +4,7 @@ version = [1, 5]
 name = "sue"
 image_size = "0x300000"        # (47 + 1) bank * 64KB
 exec_boot_ldr = 1
+alias_mask = "0xE0000000"
 
 [[adsp.mem_zone]]
 type = "ROM"
@@ -17,6 +18,13 @@ size = "0x100000"
 type = "SRAM"
 base = "0xbe000000"
 size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
 
 [fw_desc.header]
 name = "ADSPFW"


### PR DESCRIPTION
cAVS 1.5, 1.8 and 2.0 are supported by Zephyr, their configurations need alias definitions.