### PR TITLE
Set of small changes to improve code readability and fix bugs (SP2)

### DIFF
--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -66,7 +66,6 @@ static void dump_adsp(const struct adsp *adsp)
 	DUMP("\nadsp");
 	DUMP_KEY("name", "'%s'", adsp->name);
 	DUMP_KEY("image_size", "0x%x", adsp->image_size);
-	DUMP_KEY("dram_offset", "0x%x", adsp->dram_offset);
 	DUMP_KEY("exec_boot_ldr", "%d", adsp->exec_boot_ldr);
 	for (i = 0; i < ARRAY_SIZE(adsp->mem_zones); ++i) {
 		DUMP_KEY("mem_zone.idx", "%d", i);
@@ -112,10 +111,6 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 		return err_key_parse("name", NULL);
 
 	out->image_size = parse_uint32_hex_key(adsp, &ctx, "image_size", 0, &ret);
-	if (ret < 0)
-		return ret;
-
-	out->dram_offset = parse_uint32_hex_key(adsp, &ctx, "dram_offset", 0, &ret);
 	if (ret < 0)
 		return ret;
 

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -67,11 +67,11 @@ static void dump_adsp(const struct adsp *adsp)
 	DUMP_KEY("name", "'%s'", adsp->name);
 	DUMP_KEY("image_size", "0x%x", adsp->image_size);
 	DUMP_KEY("exec_boot_ldr", "%d", adsp->exec_boot_ldr);
-	for (i = 0; i < ARRAY_SIZE(adsp->mem_zones); ++i) {
+	for (i = 0; i < ARRAY_SIZE(adsp->mem.zones); ++i) {
 		DUMP_KEY("mem_zone.idx", "%d", i);
-		DUMP_KEY("mem_zone.size", "0x%x", adsp->mem_zones[i].size);
-		DUMP_KEY("mem_zone.base", "0x%x", adsp->mem_zones[i].base);
-		DUMP_KEY("mem_zone.host_offset", "0x%x", adsp->mem_zones[i].host_offset);
+		DUMP_KEY("mem_zone.size", "0x%x", adsp->mem.zones[i].size);
+		DUMP_KEY("mem_zone.base", "0x%x", adsp->mem.zones[i].base);
+		DUMP_KEY("mem_zone.host_offset", "0x%x", adsp->mem.zones[i].host_offset);
 	}
 }
 
@@ -79,7 +79,7 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 		      bool verbose)
 {
 	toml_array_t *mem_zone_array, *alias_array;
-	struct mem_zone *zone;
+	struct memory_zone *zone;
 	struct parse_ctx ctx;
 	toml_table_t *adsp;
 	toml_raw_t raw;
@@ -164,7 +164,7 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 	}
 
 	/* look for entry array */
-	memset(out->mem_zones, 0, sizeof(out->mem_zones));
+	memset(&out->mem, 0, sizeof(out->mem));
 	mem_zone_array = toml_array_in(adsp, "mem_zone");
 	if (!mem_zone_array)
 		return err_key_not_found("mem_zone");
@@ -196,7 +196,7 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 		if (zone_idx < 0)
 			return err_key_parse("mem_zone.name", "unknown zone '%s'", zone_name);
 
-		zone = &out->mem_zones[zone_idx];
+		zone = &out->mem.zones[zone_idx];
 		zone->base = parse_uint32_hex_key(mem_zone, &ctx, "base", -1, &ret);
 		if (ret < 0)
 			return err_key_parse("mem_zone", NULL);

--- a/src/adsp_config.c
+++ b/src/adsp_config.c
@@ -118,7 +118,8 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 	if (ret < 0)
 		return ret;
 
-	out->alias_mask = parse_uint32_hex_key(adsp, &ctx, "alias_mask", -ENODATA, &ret);
+	memset(&out->mem, 0, sizeof(out->mem));
+	out->mem.alias.mask = parse_uint32_hex_key(adsp, &ctx, "alias_mask", -ENODATA, &ret);
 	alias_found = !ret;
 
 	/* check everything parsed, 1 or 2 tables should be present */
@@ -153,18 +154,18 @@ static int parse_adsp(const toml_table_t *toml, struct parse_ctx *pctx, struct a
 			base = parse_uint32_hex_key(alias, &ctx, "base", -1, &ret);
 
 			if (!strncmp("cached", alias_name, sizeof("cached")))
-				out->alias_cached = base & out->alias_mask;
+				out->mem.alias.cached = base & out->mem.alias.mask;
 			else if (!strncmp("uncached", alias_name, sizeof("uncached")))
-				out->alias_uncached = base & out->alias_mask;
+				out->mem.alias.uncached = base & out->mem.alias.mask;
 		}
 	} else {
 		/* Make uncache_to_cache() an identity transform */
-		out->alias_cached = 0;
-		out->alias_mask = 0;
+		out->mem.alias.uncached = 0;
+		out->mem.alias.cached = 0;
+		out->mem.alias.mask = 0;
 	}
 
 	/* look for entry array */
-	memset(&out->mem, 0, sizeof(out->mem));
 	mem_zone_array = toml_array_in(adsp, "mem_zone");
 	if (!mem_zone_array)
 		return err_key_not_found("mem_zone");

--- a/src/elf.c
+++ b/src/elf.c
@@ -77,7 +77,7 @@ static int elf_read_sections(struct image *image, struct manifest_module *module
 		return -errno;
 	}
 
-	if (image->num_modules > 1 && module_index == 0) {
+	if (module->is_bootloader) {
 		/* In case of multiple modules first one should be bootloader,
 		 * that should not have these sections.
 		 */

--- a/src/elf.c
+++ b/src/elf.c
@@ -17,7 +17,7 @@
 
 static unsigned long uncache_to_cache(const struct image *image, unsigned long address)
 {
-	return (address & ~image->adsp->alias_mask) | image->adsp->alias_cached;
+	return (address & ~image->adsp->mem.alias.mask) | image->adsp->mem.alias.cached;
 }
 
 static int elf_read_sections(struct image *image, struct module *module,

--- a/src/elf.c
+++ b/src/elf.c
@@ -109,7 +109,7 @@ static int elf_read_sections(struct image *image, struct manifest_module *module
 			/* fall through */
 		case SHT_PROGBITS:
 			/* text or data */
-			module->fw_size += section[i].size;
+			module->output_size += section[i].size;
 
 			if (section[i].flags & SHF_EXECINSTR)
 				module->text_size += section[i].size;
@@ -637,8 +637,8 @@ int elf_parse_module(struct image *image, int module_index, const char *name)
 
 	elf_find_section(module, "");
 
-	fprintf(stdout, " module: input size %d (0x%x) bytes %d sections\n",
-		module->fw_size, module->fw_size, module->num_sections);
+	fprintf(stdout, " module: input size %zu (0x%zx) bytes %d sections\n",
+		module->output_size, module->output_size, module->num_sections);
 	fprintf(stdout, " module: text %d (0x%x) bytes\n"
 			"    data %d (0x%x) bytes\n"
 			"    bss  %d (0x%x) bytes\n\n",

--- a/src/elf.c
+++ b/src/elf.c
@@ -28,8 +28,8 @@ static int elf_read_sections(struct image *image, struct module *module,
 	size_t count;
 	int i, ret;
 	uint32_t valid = (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR);
-	unsigned long rom_base = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].base;
-	size_t rom_size = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].size;
+	unsigned long rom_base = image->adsp->mem.zones[SOF_FW_BLK_TYPE_ROM].base;
+	size_t rom_size = image->adsp->mem.zones[SOF_FW_BLK_TYPE_ROM].size;
 
 	/* read in section header */
 	ret = fseek(module->fd, hdr->shoff, SEEK_SET);
@@ -256,8 +256,8 @@ int elf_is_rom(struct image *image, Elf32_Shdr *section)
 	start = section->vaddr;
 	end = section->vaddr + section->size;
 
-	base = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].base;
-	size = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].size;
+	base = image->adsp->mem.zones[SOF_FW_BLK_TYPE_ROM].base;
+	size = image->adsp->mem.zones[SOF_FW_BLK_TYPE_ROM].size;
 
 	if (start < base || start > base + size)
 		return 0;

--- a/src/elf.c
+++ b/src/elf.c
@@ -20,7 +20,7 @@ static unsigned long uncache_to_cache(const struct image *image, unsigned long a
 	return (address & ~image->adsp->mem.alias.mask) | image->adsp->mem.alias.cached;
 }
 
-static int elf_read_sections(struct image *image, struct module *module,
+static int elf_read_sections(struct image *image, struct manifest_module *module,
 			     int module_index)
 {
 	Elf32_Ehdr *hdr = &module->hdr;
@@ -151,7 +151,7 @@ static int elf_read_sections(struct image *image, struct module *module,
 	return 0;
 }
 
-static int elf_read_programs(struct image *image, struct module *module)
+static int elf_read_programs(struct image *image, struct manifest_module *module)
 {
 	Elf32_Ehdr *hdr = &module->hdr;
 	Elf32_Phdr *prg = module->prg;
@@ -207,7 +207,7 @@ static int elf_read_programs(struct image *image, struct module *module)
 	return 0;
 }
 
-static int elf_read_hdr(struct image *image, struct module *module)
+static int elf_read_hdr(struct image *image, struct manifest_module *module)
 {
 	Elf32_Ehdr *hdr = &module->hdr;
 	size_t count;
@@ -266,7 +266,7 @@ int elf_is_rom(struct image *image, Elf32_Shdr *section)
 	return 1;
 }
 
-static void elf_module_size(struct image *image, struct module *module,
+static void elf_module_size(struct image *image, struct manifest_module *module,
 			    Elf32_Shdr *section, uint32_t lma, int index)
 {
 	switch (section->type) {
@@ -310,7 +310,7 @@ static void elf_module_size(struct image *image, struct module *module,
 	}
 }
 
-static void elf_module_size_reloc(struct image *image, struct module *module,
+static void elf_module_size_reloc(struct image *image, struct manifest_module *module,
 				  Elf32_Shdr *section, int index)
 {
 	switch (section->type) {
@@ -346,7 +346,7 @@ static void elf_module_size_reloc(struct image *image, struct module *module,
 	}
 }
 
-static void elf_module_limits(struct image *image, struct module *module)
+static void elf_module_limits(struct image *image, struct manifest_module *module)
 {
 	Elf32_Shdr *section;
 	uint32_t valid = (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR);
@@ -408,10 +408,10 @@ static void elf_module_limits(struct image *image, struct module *module)
 }
 
 /* make sure no section overlap from any modules */
-int elf_validate_section(struct image *image, struct module *module,
+int elf_validate_section(struct image *image, struct manifest_module *module,
 			 Elf32_Shdr *section, int index)
 {
-	struct module *m;
+	struct manifest_module *m;
 	Elf32_Shdr *s;
 	uint32_t valid = (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR);
 	int i, j;
@@ -464,7 +464,7 @@ err:
 /* make sure no section overlaps from any modules */
 int elf_validate_modules(struct image *image)
 {
-	struct module *module;
+	struct manifest_module *module;
 	Elf32_Shdr *section;
 	uint32_t valid = (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR);
 	int i, j, ret;
@@ -498,7 +498,7 @@ int elf_validate_modules(struct image *image)
 	return 0;
 }
 
-int elf_find_section(const struct module *module, const char *name)
+int elf_find_section(const struct manifest_module *module, const char *name)
 {
 	const Elf32_Ehdr *hdr = &module->hdr;
 	const Elf32_Shdr *section, *s;
@@ -546,7 +546,7 @@ out:
 	return ret;
 }
 
-int elf_read_section(const struct module *module, const char *section_name,
+int elf_read_section(const struct manifest_module *module, const char *section_name,
 		     const Elf32_Shdr **dst_section, void **dst_buff)
 {
 	const Elf32_Shdr *section;
@@ -585,7 +585,7 @@ int elf_read_section(const struct module *module, const char *section_name,
 
 int elf_parse_module(struct image *image, int module_index, const char *name)
 {
-	struct module *module;
+	struct manifest_module *module;
 	uint32_t rem;
 	int ret = 0;
 
@@ -676,7 +676,7 @@ hdr_err:
 
 void elf_free_module(struct image *image, int module_index)
 {
-	struct module *module = &image->module[module_index];
+	struct manifest_module *module = &image->module[module_index];
 
 	free(module->prg);
 	free(module->section);

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -41,9 +41,9 @@ static int ext_man_open_file(struct image *image)
 	return 0;
 }
 
-static const struct module *ext_man_find_module(const struct image *image)
+static const struct manifest_module *ext_man_find_module(const struct image *image)
 {
-	const struct module *module;
+	const struct manifest_module *module;
 	int i;
 
 	/* when there is more than one module, then first one is bootloader */
@@ -86,7 +86,7 @@ static int ext_man_validate(uint32_t section_size, const void *section_data)
 	}
 }
 
-static int ext_man_build(const struct module *module,
+static int ext_man_build(const struct manifest_module *module,
 			 struct ext_man_header **dst_buff)
 {
 	struct ext_man_header ext_man;
@@ -135,7 +135,7 @@ out:
 
 int ext_man_write(struct image *image)
 {
-	const struct module *module;
+	const struct manifest_module *module;
 	struct ext_man_header *ext_man = NULL;
 	int count;
 	int ret;

--- a/src/ext_manifest.c
+++ b/src/ext_manifest.c
@@ -46,9 +46,12 @@ static const struct manifest_module *ext_man_find_module(const struct image *ima
 	const struct manifest_module *module;
 	int i;
 
-	/* when there is more than one module, then first one is bootloader */
-	for (i = image->num_modules == 1 ? 0 : 1; i < image->num_modules; i++) {
+	for (i = 0; i < image->num_modules; i++) {
 		module = &image->module[i];
+
+		if (module->is_bootloader)
+			continue;
+
 		if (elf_find_section(module, EXT_MAN_DATA_SECTION) >= 0)
 			return module;
 	}

--- a/src/file_simple.c
+++ b/src/file_simple.c
@@ -12,9 +12,8 @@
 #include <rimage/manifest.h>
 #include <rimage/file_utils.h>
 
-static int get_mem_zone_type(struct image *image, Elf32_Shdr *section)
+static int get_mem_zone_type(const struct memory_config *memory, Elf32_Shdr *section)
 {
-	const struct adsp *adsp = image->adsp;
 	uint32_t start, end, base, size;
 	int i;
 
@@ -22,8 +21,8 @@ static int get_mem_zone_type(struct image *image, Elf32_Shdr *section)
 	end = section->vaddr + section->size;
 
 	for (i = SOF_FW_BLK_TYPE_START; i < SOF_FW_BLK_TYPE_NUM; i++) {
-		base =  adsp->mem_zones[i].base;
-		size =  adsp->mem_zones[i].size;
+		base =  memory->zones[i].base;
+		size =  memory->zones[i].size;
 
 		if (start < base)
 			continue;
@@ -55,11 +54,11 @@ static int write_block(struct image *image, struct module *module,
 		block.size += padding;
 	}
 
-	ret = get_mem_zone_type(image, section);
+	ret = get_mem_zone_type(&image->adsp->mem, section);
 	if (ret != SOF_FW_BLK_TYPE_INVALID) {
 		block.type = ret;
-		block.offset = section->vaddr - adsp->mem_zones[ret].base
-			+ adsp->mem_zones[ret].host_offset;
+		block.offset = section->vaddr - adsp->mem.zones[ret].base
+			+ adsp->mem.zones[ret].host_offset;
 	} else {
 		fprintf(stderr, "error: invalid block address/size 0x%x/0x%x\n",
 			section->vaddr, section->size);

--- a/src/file_simple.c
+++ b/src/file_simple.c
@@ -294,11 +294,11 @@ int simple_write_firmware(struct image *image)
 
 	for (i = 0; i < image->num_modules; i++) {
 		module = &image->module[i];
-		module->fw_size += sizeof(struct snd_sof_blk_hdr) *
+		module->output_size += sizeof(struct snd_sof_blk_hdr) *
 				(module->num_sections - module->num_bss);
-		module->fw_size += sizeof(struct snd_sof_mod_hdr) *
+		module->output_size += sizeof(struct snd_sof_mod_hdr) *
 				hdr.num_modules;
-		hdr.file_size += module->fw_size;
+		hdr.file_size += module->output_size;
 	}
 
 	count = fwrite(&hdr, sizeof(hdr), 1, image->out_fd);

--- a/src/file_simple.c
+++ b/src/file_simple.c
@@ -37,7 +37,7 @@ static int get_mem_zone_type(const struct memory_config *memory, Elf32_Shdr *sec
 
 static int block_idx;
 
-static int write_block(struct image *image, struct module *module,
+static int write_block(struct image *image, struct manifest_module *module,
 		       Elf32_Shdr *section)
 {
 	const struct adsp *adsp = image->adsp;
@@ -109,7 +109,7 @@ out:
 	return ret;
 }
 
-static int simple_write_module(struct image *image, struct module *module)
+static int simple_write_module(struct image *image, struct manifest_module *module)
 {
 	struct snd_sof_mod_hdr hdr;
 	Elf32_Shdr *section;
@@ -191,7 +191,7 @@ static int simple_write_module(struct image *image, struct module *module)
 	return padding;
 }
 
-static int write_block_reloc(struct image *image, struct module *module)
+static int write_block_reloc(struct image *image, struct manifest_module *module)
 {
 	struct snd_sof_blk_hdr block;
 	size_t count;
@@ -240,7 +240,7 @@ out:
 	return ret;
 }
 
-static int simple_write_module_reloc(struct image *image, struct module *module)
+static int simple_write_module_reloc(struct image *image, struct manifest_module *module)
 {
 	struct snd_sof_mod_hdr hdr;
 	size_t count;
@@ -282,7 +282,7 @@ static int simple_write_module_reloc(struct image *image, struct module *module)
 int simple_write_firmware(struct image *image)
 {
 	struct snd_sof_fw_header hdr;
-	struct module *module;
+	struct manifest_module *module;
 	size_t count;
 	int i, ret;
 

--- a/src/include/rimage/elf.h
+++ b/src/include/rimage/elf.h
@@ -5,6 +5,9 @@
  * Portions Copyright 2009 The Go Authors.  All rights reserved.
  */
 
+#ifndef __ELF_H__
+#define __ELF_H__
+
 /*
  * ELF definitions that are independent of architecture or word size.
  */
@@ -929,3 +932,5 @@ typedef struct {
 #define	ELF32SHDRSIZE	sizeof(Elf32_Shdr)
 #define	ELF32SYMSIZE	sizeof(Elf32_Sym)
 #define	ELF32RELSIZE	8
+
+#endif /* __ELF_H__ */

--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <rimage/sof/user/manifest.h>
 #include <rimage/css.h>
 #include <rimage/cse.h>
@@ -53,6 +54,8 @@ struct manifest_module {
 
 	/* Following fields are used in manifest creation process */
 	int fw_size;
+
+	bool is_bootloader;
 
 	/* Size of the module in the output image.
 	 * Includes text and data sections size + image headers*/

--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -71,7 +71,6 @@ struct manifest_module {
 };
 
 #define MAN_PAGE_SIZE		4096
-#define MAN_MAX_SIZE_V1_8       (38 * 1024)
 
 /* start offset for modules built using xcc */
 #define DEFAULT_XCC_MOD_OFFSET		0x8

--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -54,6 +54,10 @@ struct manifest_module {
 	/* Following fields are used in manifest creation process */
 	int fw_size;
 
+	/* Size of the module in the output image.
+	 * Includes text and data sections size + image headers*/
+	size_t output_size;
+
 	/* executable header module */
 	int exec_header;
 

--- a/src/include/rimage/manifest.h
+++ b/src/include/rimage/manifest.h
@@ -7,10 +7,61 @@
 #define __MANIFEST_H__
 
 #include <stdint.h>
+#include <stdio.h>
 #include <rimage/sof/user/manifest.h>
 #include <rimage/css.h>
 #include <rimage/cse.h>
 #include <rimage/plat_auth.h>
+#include <rimage/elf.h>
+
+/*
+ * Manifest module data
+ */
+struct manifest_module {
+	/* This fields will be moved to module structure */
+	const char *elf_file;
+	FILE *fd;
+
+	Elf32_Ehdr hdr;
+	Elf32_Shdr *section;
+	Elf32_Phdr *prg;
+	char *strings;
+
+	uint32_t text_start;
+	uint32_t text_end;
+	uint32_t data_start;
+	uint32_t data_end;
+	uint32_t bss_start;
+	uint32_t bss_end;
+
+	int num_sections;
+	int num_bss;
+	int bss_index;
+
+	/* sizes do not include any gaps */
+	int bss_size;
+	int text_size;
+	int data_size;
+
+	/* sizes do include gaps to nearest page */
+	int bss_file_size;
+	int text_file_size;
+	int data_file_size;
+
+	/* total file size */
+	size_t file_size;
+
+	/* Following fields are used in manifest creation process */
+	int fw_size;
+
+	/* executable header module */
+	int exec_header;
+
+	/* module offset in image file */
+	size_t foffset;
+
+	size_t text_fixup_size;
+};
 
 #define MAN_PAGE_SIZE		4096
 #define MAN_MAX_SIZE_V1_8       (38 * 1024)

--- a/src/include/rimage/misc_utils.h
+++ b/src/include/rimage/misc_utils.h
@@ -3,6 +3,9 @@
  * Copyright(c) 2023 Intel Corporation. All rights reserved.
  */
 
+#ifndef __MISC_UTILS_H__
+#define __MISC_UTILS_H__
+
 #include <stdint.h>
 
 /**
@@ -11,3 +14,16 @@
  * @param size of the array
  */
 void bytes_swap(uint8_t *ptr, uint32_t size);
+
+struct name_val {
+	const char *name;
+	unsigned long value;
+};
+
+#define NAME_VAL_ENTRY(x) { .name = #x, .value = x }
+#define NAME_VAL_END { .name = 0, .value = 0 }
+
+void print_enum(unsigned long value, const struct name_val *values);
+void print_flags(unsigned long value, const struct name_val *flags);
+
+#endif /* __MISC_UTILS_H__ */

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -146,7 +146,6 @@ struct adsp {
 	struct mem_zone mem_zones[SOF_FW_BLK_TYPE_NUM];
 
 	uint32_t image_size;
-	uint32_t dram_offset;
 
 	uint32_t alias_cached;
 	uint32_t alias_uncached;

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -6,11 +6,10 @@
 #ifndef __RIMAGE_H__
 #define __RIMAGE_H__
 
-#include "elf.h"
-
 #include <stdint.h>
 #include <stdio.h>
 
+#include <rimage/manifest.h>
 #include <rimage/cavs/cavs_ext_manifest.h>
 #include <rimage/sof/kernel/fw.h>
 
@@ -18,51 +17,6 @@
 #define MAX_MODULES		32
 
 struct adsp;
-struct manifest;
-struct man_module;
-
-/*
- * ELF module data
- */
-struct module {
-	const char *elf_file;
-	FILE *fd;
-
-	Elf32_Ehdr hdr;
-	Elf32_Shdr *section;
-	Elf32_Phdr *prg;
-	char *strings;
-
-	uint32_t text_start;
-	uint32_t text_end;
-	uint32_t data_start;
-	uint32_t data_end;
-	uint32_t bss_start;
-	uint32_t bss_end;
-	uint32_t foffset;
-
-	int num_sections;
-	int num_bss;
-	int fw_size;
-	int bss_index;
-
-	/* sizes do not include any gaps */
-	int bss_size;
-	int text_size;
-	int data_size;
-
-	/* sizes do include gaps to nearest page */
-	int bss_file_size;
-	int text_file_size;
-	int text_fixup_size;
-	int data_file_size;
-
-	/* total file size */
-	size_t file_size;
-
-	/* executable header module */
-	int exec_header;
-};
 
 /*
  * Firmware image context.
@@ -79,7 +33,7 @@ struct image {
 	int verbose;
 	int reloc;	/* ELF data is relocatable */
 	int num_modules;
-	struct module module[MAX_MODULES];
+	struct manifest_module module[MAX_MODULES];
 	uint32_t image_end;/* module end, equal to output image size */
 	int meu_offset;
 	const char *verify_file;
@@ -219,10 +173,10 @@ int elf_parse_module(struct image *image, int module_index, const char *name);
 void elf_free_module(struct image *image, int module_index);
 int elf_is_rom(struct image *image, Elf32_Shdr *section);
 int elf_validate_modules(struct image *image);
-int elf_find_section(const struct module *module, const char *name);
-int elf_read_section(const struct module *module, const char *name,
+int elf_find_section(const struct manifest_module *module, const char *name);
+int elf_read_section(const struct manifest_module *module, const char *name,
 		     const Elf32_Shdr **dst_section, void **dst_buff);
-int elf_validate_section(struct image *image, struct module *module,
+int elf_validate_section(struct image *image, struct manifest_module *manifest_module,
 			 Elf32_Shdr *section, int index);
 
 #endif

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -110,10 +110,14 @@ struct image {
 	uint32_t imr_type;
 };
 
-struct mem_zone {
+struct memory_zone {
 	uint32_t base;
 	uint32_t size;
 	uint32_t host_offset;
+};
+
+struct memory_config {
+	struct memory_zone zones[SOF_FW_BLK_TYPE_NUM];
 };
 
 struct fw_image_ext_mod_config {
@@ -143,7 +147,7 @@ struct fw_image_manifest_module {
  */
 struct adsp {
 	const char *name;
-	struct mem_zone mem_zones[SOF_FW_BLK_TYPE_NUM];
+	struct memory_config mem;
 
 	uint32_t image_size;
 

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -62,6 +62,9 @@ struct image {
 	uint16_t fw_ver_build;
 
 	uint32_t imr_type;
+
+	/* Output image is a loadable module */
+	bool loadable_module;
 };
 
 struct memory_zone {

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -116,8 +116,15 @@ struct memory_zone {
 	uint32_t host_offset;
 };
 
+struct memory_alias {
+	uint32_t mask;
+	uint32_t cached;
+	uint32_t uncached;
+};
+
 struct memory_config {
 	struct memory_zone zones[SOF_FW_BLK_TYPE_NUM];
+	struct memory_alias alias;
 };
 
 struct fw_image_ext_mod_config {
@@ -150,10 +157,6 @@ struct adsp {
 	struct memory_config mem;
 
 	uint32_t image_size;
-
-	uint32_t alias_cached;
-	uint32_t alias_uncached;
-	uint32_t alias_mask;
 
 	int (*write_firmware_ext_man)(struct image *image);
 	int (*write_firmware)(struct image *image);

--- a/src/include/rimage/sof/user/manifest.h
+++ b/src/include/rimage/sof/user/manifest.h
@@ -30,6 +30,9 @@
 #define SOF_MAN_MOD_INIT_CONFIG_BASE_CFG               0 /* Base config only */
 #define SOF_MAN_MOD_INIT_CONFIG_BASE_CFG_WITH_EXT      1 /* Base config with extension */
 
+#define MAN_MAX_SIZE_V1_8		(38 * 1024)
+
+
 struct sof_man_module_type {
 	uint32_t load_type:4;	/* SOF_MAN_MOD_TYPE_ */
 	uint32_t auto_start:1;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -662,6 +662,10 @@ static int man_create_modules(struct image *image, struct sof_man_fw_desc *desc,
 
 	for (; i < image->num_modules; i++) {
 		man_module = (void *)desc + SOF_MAN_MODULE_OFFSET(i - offset);
+		/* Use manifest created using toml files as template */
+		assert(i < image->adsp->modules->mod_man_count);
+		memcpy(man_module, &image->adsp->modules->mod_man[i], sizeof(*man_module));
+
 		module = &image->module[i];
 
 		if (i == 0)
@@ -693,12 +697,14 @@ static void man_create_modules_in_config(struct image *image, struct sof_man_fw_
 	if (!modules)
 		return;
 
-	/*skip bringup and base module */
-	for (i = 2; i < modules->mod_man_count; i++) {
+	/* skip modules passed as parameters. Their manifests have already been copied by the
+	 * man_create_modules function. */
+	for (i = image->num_modules; i < modules->mod_man_count; i++) {
 		man_module = (void *)desc + SOF_MAN_MODULE_OFFSET(i);
 		memcpy(man_module, &modules->mod_man[i], sizeof(*man_module));
 	}
 
+	/* We need to copy the configurations for all modules. */
 	cfg_start = (void *)desc + SOF_MAN_MODULE_OFFSET(i);
 	memcpy(cfg_start, modules->mod_cfg, modules->mod_cfg_count * sizeof(struct sof_man_mod_config));
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -141,7 +141,7 @@ static int man_init_image_v2_5(struct image *image)
 
 /* we should call this after all segments size set up via iterate */
 static uint32_t elf_to_file_offset(struct image *image,
-				   struct module *module,
+				   struct manifest_module *module,
 				   struct sof_man_module *man_module,
 				   Elf32_Shdr *section)
 {
@@ -174,7 +174,7 @@ static uint32_t elf_to_file_offset(struct image *image,
 
 /* write SRAM sections */
 static int man_copy_sram(struct image *image, Elf32_Shdr *section,
-			 struct module *module,
+			 struct manifest_module *module,
 			 struct sof_man_module *man_module,
 			 int section_idx)
 {
@@ -227,7 +227,7 @@ static int man_copy_sram(struct image *image, Elf32_Shdr *section,
 }
 
 static int man_copy_elf_section(struct image *image, Elf32_Shdr *section,
-				struct module *module,
+				struct manifest_module *module,
 				struct sof_man_module *man_module, int idx)
 {
 	int ret;
@@ -244,7 +244,7 @@ static int man_copy_elf_section(struct image *image, Elf32_Shdr *section,
 	return 0;
 }
 
-static int man_get_module_manifest(struct image *image, struct module *module,
+static int man_get_module_manifest(struct image *image, struct manifest_module *module,
 				   struct sof_man_module *man_module)
 {
 	Elf32_Shdr *section;
@@ -371,7 +371,7 @@ err:
 	return -EINVAL;
 }
 
-static int man_module_create(struct image *image, struct module *module,
+static int man_module_create(struct image *image, struct manifest_module *module,
 			     struct sof_man_module *man_module)
 {
 	/* create module and segments */
@@ -502,7 +502,7 @@ out:
 	return 0;
 }
 
-static int man_module_create_reloc(struct image *image, struct module *module,
+static int man_module_create_reloc(struct image *image, struct manifest_module *module,
 				   struct sof_man_module *man_module)
 {
 	/* create module and segments */
@@ -634,7 +634,7 @@ static int man_write_fw_mod(struct image *image)
 static int man_create_modules(struct image *image, struct sof_man_fw_desc *desc,
 			      int file_text_offset)
 {
-	struct module *module;
+	struct manifest_module *module;
 	struct sof_man_module *man_module;
 	int err;
 	int i = 0, offset = 0;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -774,7 +774,9 @@ int man_write_fw_v1_5(struct image *image)
 
 	/* create each module */
 	m->desc.header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_5);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_5);
+	if (ret)
+		goto err;
 
 	fprintf(stdout, "Firmware completing manifest v1.5\n");
 
@@ -844,7 +846,10 @@ int man_write_fw_v1_5_sue(struct image *image)
 
 	/* create each module - subtract the boot loader exec header */
 	m->desc.header.num_module_entries = image->num_modules - 1;
-	man_create_modules(image, &m->desc, FILE_TEXT_OFFSET_V1_5_SUE);
+	ret = man_create_modules(image, &m->desc, FILE_TEXT_OFFSET_V1_5_SUE);
+	if (ret)
+		goto err;
+
 	fprintf(stdout, "Firmware completing manifest v1.5\n");
 
 	/* write preload page count */
@@ -915,7 +920,9 @@ int man_write_fw_v1_8(struct image *image)
 
 	/* create each module */
 	m->desc.header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	if (ret)
+		goto err;
 
 	fprintf(stdout, "Firmware completing manifest v1.8\n");
 
@@ -1033,7 +1040,9 @@ int man_write_fw_meu_v1_5(struct image *image)
 
 	/* create each module */
 	desc->header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_5);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_5);
+	if (ret)
+		goto err;
 
 	fprintf(stdout, "Firmware completing manifest v1.5\n");
 
@@ -1117,7 +1126,9 @@ int man_write_fw_meu_v1_8(struct image *image)
 
 	/* create each module */
 	desc->header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	if (ret)
+		goto err;
 
 	fprintf(stdout, "Firmware completing manifest v1.8\n");
 
@@ -1201,7 +1212,10 @@ int man_write_fw_meu_v2_5(struct image *image)
 
 	/* create each module */
 	desc->header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	if (ret)
+		goto err;
+
 	/* platform config defines some modules except bringup & base modules */
 	man_create_modules_in_config(image, desc);
 
@@ -1288,7 +1302,10 @@ int man_write_fw_v2_5(struct image *image)
 
 	/* create each module */
 	m->desc.header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	if (ret)
+		goto err;
+
 	/* platform config defines some modules except bringup & base modules */
 	man_create_modules_in_config(image, desc);
 
@@ -1438,7 +1455,10 @@ int man_write_fw_ace_v1_5(struct image *image)
 
 	/* create each module */
 	m->desc.header.num_module_entries = image->num_modules;
-	man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	ret = man_create_modules(image, desc, FILE_TEXT_OFFSET_V1_8);
+	if (ret)
+		goto err;
+
 	/* platform config defines some modules except bringup & base modules */
 	man_create_modules_in_config(image, desc);
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -36,7 +36,7 @@ static int man_open_rom_file(struct image *image)
 	if (ret)
 		return ret;
 
-	size = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].size;
+	size = image->adsp->mem.zones[SOF_FW_BLK_TYPE_ROM].size;
 
 	/* allocate ROM image  */
 	image->rom_image = calloc(size, 1);

--- a/src/misc_utils.c
+++ b/src/misc_utils.c
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
  * Copyright(c) 2018-2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
  */
 
+#include <stdio.h>
 #include <rimage/misc_utils.h>
 
 void bytes_swap(uint8_t *ptr, uint32_t size)
@@ -15,4 +18,34 @@ void bytes_swap(uint8_t *ptr, uint32_t size)
 		ptr[index] = ptr[size - 1 - index];
 		ptr[size - 1 - index] = tmp;
 	}
+}
+
+void print_enum(unsigned long value, const struct name_val *values)
+{
+	while (values->name) {
+		if (values->value == value) {
+			fprintf(stdout, "%s\n", values->name);
+			return;
+		}
+		
+		values++;
+	}
+
+	printf("Unknown: 0x%lx\n", value);
+}
+
+void print_flags(unsigned long value, const struct name_val *flags)
+{
+	while (flags->name) {
+		if (value & flags->value) {
+			fprintf(stdout, "%s ", flags->name);
+			value &= ~flags->value;
+		}
+
+		flags++;
+	}
+
+	if (value)
+		fprintf(stdout, "+ 0x%lx", value);
+	printf("\n");
 }

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -206,6 +206,12 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	if (image.num_modules > image.adsp->modules->mod_man_count) {
+		fprintf(stderr, "error: Each ELF input module requires entry in toml file.\n");
+		ret = -EINVAL;
+		goto out;
+	}
+
 	/* getopt reorders argv[] */
 	for (i = first_non_opt; i < argc; i++) {
 		/* When there is more than one module, then first one is bootloader.

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -204,6 +204,10 @@ int main(int argc, char *argv[])
 
 	/* getopt reorders argv[] */
 	for (i = first_non_opt; i < argc; i++) {
+		/* When there is more than one module, then first one is bootloader. */
+		image.module[i - first_non_opt].is_bootloader = image.num_modules > 1 &&
+			i == first_non_opt;
+
 		fprintf(stdout, "\nModule Reading %s\n", argv[i]);
 		ret = elf_parse_module(&image, i - first_non_opt, argv[i]);
 		if (ret < 0)


### PR DESCRIPTION
* Added header guard in elf.h file to allow safe include this header by multiple units.
* The man create modules function may return an error that was ignored. Added check of a return value.
* There was no dram_offset value in any configuration file. It also wasn't used anywhere in the code. So the code reading it from the tolm file has been removed.
* Added functions to print enum and flags value. Added name_val structure representing name/value tuple. Added function
print_enum which displays the name of the enum corresponding to a given value. Added print_flags function which display names of flags constituting a given value.
* Create new memory_config structure. Moved mem_zone field from adsp structure to the new memory_config structure
* Moved memory alias configuration to a new struct. A new memory_alias structure containing memory address alias configurations has been created. It was placed in the memory_config structure.
* Rename struct module to manifest_module. Changing the name of the structure type is a prelude to separating information about the elf file from the information used during creation of a manifest.
* Renamed fw_size field in manifest_module structure to output_size. New name is a more clear. Added description for this field.
* A is_bootloader field has been added to determine whether a module is a bootloader. This is clearer than checking the module index and the number of modules in different places in the program.
* Add suport for loadable modules. A new -l parameter has been added to the program's command line. It instructs the program to not treat the first module as a bootloader and not to skip the bss section for it.
* Moved MAN_MAX_SIZE_V1_8 define to the public manifest header. Currently, sof incorrectly includes a private manifest.h header belonging to the manifest.c module. Moved the MAN_MAX_SIZE_V1_8 definition used by sof, to the public manifest header to allow sof to switch to using the correct file.