### PR TITLE
[FIX] Fix for manifest: Use module manifest from toml as a template for elf modules

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -662,9 +662,13 @@ static int man_create_modules(struct image *image, struct sof_man_fw_desc *desc,
 
 	for (; i < image->num_modules; i++) {
 		man_module = (void *)desc + SOF_MAN_MODULE_OFFSET(i - offset);
-		/* Use manifest created using toml files as template */
-		assert(i < image->adsp->modules->mod_man_count);
-		memcpy(man_module, &image->adsp->modules->mod_man[i], sizeof(*man_module));
+
+		/* Some platforms dont have modules configuration in toml file */
+		if (image->adsp->modules) {
+			/* Use manifest created using toml files as template */
+			assert(i < image->adsp->modules->mod_man_count);
+			memcpy(man_module, &image->adsp->modules->mod_man[i], sizeof(*man_module));
+		}
 
 		module = &image->module[i];
 

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -206,7 +206,8 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (image.num_modules > image.adsp->modules->mod_man_count) {
+	/* Some platforms dont have modules configuration in toml file */
+	if (image.adsp->modules && image.num_modules > image.adsp->modules->mod_man_count) {
 		fprintf(stderr, "error: Each ELF input module requires entry in toml file.\n");
 		ret = -EINVAL;
 		goto out;


### PR DESCRIPTION
Some platforms (eg. tgl) dont have modules configuration in a toml files. An attempt to use the configuration template ended with a reference to a null pointer. This commit fixes this issue.