### PR TITLE
[RFC] Remove OpenSSL 1.x support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,8 @@ if(${CMAKE_HOST_WIN32})
 	endif()
 endif()
 
-target_link_libraries(rimage PRIVATE crypto)
+find_package(OpenSSL REQUIRED)
+target_link_libraries(rimage PRIVATE crypto OpenSSL::SSL)
 
 target_include_directories(rimage PRIVATE
 	src/include/

--- a/src/hash.c
+++ b/src/hash.c
@@ -24,31 +24,6 @@
 
 #define DEBUG_HASH 0
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
-EVP_MD_CTX *EVP_MD_CTX_new(void);
-
-static void *OPENSSL_zalloc(size_t num)
-{
-	void *ret = OPENSSL_malloc(num);
-
-	if (ret)
-		memset(ret, 0, num);
-	return ret;
-}
-
-EVP_MD_CTX *EVP_MD_CTX_new(void)
-{
-	return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
-}
-
-void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
-{
-	EVP_MD_CTX_cleanup(ctx);
-	OPENSSL_free(ctx);
-}
-#endif
-
 static int hash_error(struct hash_context *context, int errcode, const char *msg)
 {
 	EVP_MD_CTX_free(context->context);


### PR DESCRIPTION
Remove OpenSSL 1.x support as it is reaching end-of-life in many distros.