### PR TITLE
cmake: remove "install" target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,5 +64,3 @@ target_include_directories(rimage PRIVATE
 	src/include/
 	tomlc99/
 )
-
-install(TARGETS rimage DESTINATION bin)


### PR DESCRIPTION
The deleted "install" target copied only the rimage executable and left the config files behind. This gave the wrong impression that the executable is useful without config files.

"Installing" also gave the wrong impression that rimage versions are somewhat stable and relatively independent of SOF versions: they're not. In fact there is no such thing as an rimage "version": everyone should always use the exact rimage _git commit_ from the west manifest or git submodule. There are no rimage "releases" and no semantic versioning or anything like it, rimage is effectively part of the SOF source and build and run directly from its build directory by practically every SOF developer and SOF CI thanks to
```
  sof/src/arch/xtensa/CMakeLists.txt#ExternalProject_Add(rimage_ep ...
  sof/scripts/xtensa-build-zephyr.py#def build_rimage()
  sof/zephyr/CMakeLists.txt#set(RIMAGE_CONFIG_PATH ...
```
etc.

Providing an "install" target greatly increases the chances of different people and CIs using different rimage versions which is the last thing we want considering the many significant rimage changes happening right now, examples:

- https://github.com/zephyrproject-rtos/zephyr/pull/56099
- https://github.com/zephyrproject-rtos/zephyr/pull/54700
- https://github.com/thesofproject/sof/issues/7270
- https://github.com/thesofproject/sof/issues/7304
- https://github.com/thesofproject/sof/pull/7320
- https://github.com/thesofproject/rimage/pull/155

While it's useful for multiple files (e.g.: config files), a CMake target was always overkill to copy a single file. Someone or some script who really wants to copy the rimage binary to some other place that the build directory for some (discouraged) reason _can still do so_ with a much more basic, simpler and more transparent file copy command.

Finally, the default "bin" DESTINATION required root access which is otherwise totally unncessary to build SOF.