### PR TITLE
kpb: update kpb uuid for lnl

### DIFF
--- a/config/lnl.toml
+++ b/config/lnl.toml
@@ -387,7 +387,7 @@ count = 19
 
 	[[module.entry]]
 	name = "KPB"
-	uuid = "D8218443-5FF3-4A4C-B388-6CFE07B9562E"
+	uuid = "A8A0CB32-4A77-4DB1-85C7-53D7EE07BCE6"
 	affinity_mask = "0x1"
 	instance_count = "1"
 	domain_types = "0"


### PR DESCRIPTION
Change of uuid
regarding Windows compatibility.

It was already changed for MTL, but need to be updated also for LNL.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>
