### PR TITLE
file_simple: Allocate correct buffer size for writing sections out

### DIFF
--- a/src/file_simple.c
+++ b/src/file_simple.c
@@ -71,7 +71,7 @@ static int write_block(struct image *image, struct manifest_module *module,
 		return file_error("Write header failed", image->out_file);
 
 	/* alloc data data */
-	buffer = calloc(1, section->size);
+	buffer = calloc(1, block.size);
 	if (!buffer)
 		return -ENOMEM;
 


### PR DESCRIPTION
The original size given to the "calloc" call did not account for the necessity to pad section sizes to a multiple of 4 bytes. As such, every time we wrote a section that did not have a size multiple of 4 we would overflow the allocated buffer.

Fix the calloc call to account for that padding requirement.