### PR TITLE
Config: Add Aria module to tgl-cavs.toml and tgl-h-cavs.toml

### DIFF
--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -60,7 +60,7 @@ name = "ADSPFW"
 load_offset = "0x30000"
 
 [module]
-count = 15
+count = 16
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
@@ -388,3 +388,28 @@ count = 15
 	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
 			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
 			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]
+
+	# Aria module config
+	[[module.entry]]
+	name = "ARIA"
+	uuid = "99F7166D-372C-43EF-81F6-22007AA15F03"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	init_config = "1"
+	module_type = "30"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 260, 1063000, 16, 21, 0, 0, 0,
+				1, 0, 0, 0, 260, 1873500, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 260, 2680000, 32, 42, 0, 0, 0,
+				3, 0, 0, 0, 260, 3591000, 64, 85, 0, 0, 0,
+				4, 0, 0, 0, 260, 4477000, 96, 128, 0, 0, 0,
+				5, 0, 0, 0, 260, 7195000, 192, 192, 0, 0, 0]

--- a/config/tgl-h-cavs.toml
+++ b/config/tgl-h-cavs.toml
@@ -60,7 +60,7 @@ name = "ADSPFW"
 load_offset = "0x30000"
 
 [module]
-count = 15
+count = 16
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
@@ -388,3 +388,28 @@ count = 15
 	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
 			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
 			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]
+
+	# Aria module config
+	[[module.entry]]
+	name = "ARIA"
+	uuid = "99F7166D-372C-43EF-81F6-22007AA15F03"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	init_config = "1"
+	module_type = "30"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 260, 1063000, 16, 21, 0, 0, 0,
+				1, 0, 0, 0, 260, 1873500, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 260, 2680000, 32, 42, 0, 0, 0,
+				3, 0, 0, 0, 260, 3591000, 64, 85, 0, 0, 0,
+				4, 0, 0, 0, 260, 4477000, 96, 128, 0, 0, 0,
+				5, 0, 0, 0, 260, 7195000, 192, 192, 0, 0, 0]


### PR DESCRIPTION
This patch adds Aria module for TGL and TGL-H platforms. The used configuration data is copy from mtl.toml. This change allows to use Aria component in topologies.