### PR TITLE
rimage.c: fix bug where -p requires a new and ignored parameter

### DIFF
--- a/src/rimage.c
+++ b/src/rimage.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
 
 	image.imr_type = MAN_DEFAULT_IMR_TYPE;
 
-	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:p:l")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:pl")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;


### PR DESCRIPTION
Fixes commit 6e3abe6afed3 ("rimage: Add suport for loadable modules")

It looks like that commit mistook the `:` sign as a separator. This accidentally added the requirement to give `-p` a parameter which is then ignored. Remove the spurious `:`.