### PR TITLE
Config: Add crossover component for TGL and TGL-H cAVS platforms

### DIFF
--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -60,7 +60,7 @@ name = "ADSPFW"
 load_offset = "0x30000"
 
 [module]
-count = 17
+count = 18
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
@@ -423,6 +423,25 @@ count = 17
 	domain_types = "0"
 	load_type = "0"
 	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# Crossover module config
+	# Note: Crossover has init_config set to 1 to let kernel know that the base_cfg_ext needs to
+	# be appended to the IPC payload. The Extension is needed to know the output pin indices.
+	[[module.entry]]
+	name = "XOVER"
+	uuid = "948C9AD1-806A-4131-AD6C-B2BDA9E35A9F"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	init_config = "1"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 	# pin = [dir, type, sample rate, size, container, channel-cfg]

--- a/config/tgl-h-cavs.toml
+++ b/config/tgl-h-cavs.toml
@@ -60,7 +60,7 @@ name = "ADSPFW"
 load_offset = "0x30000"
 
 [module]
-count = 17
+count = 18
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
@@ -423,6 +423,25 @@ count = 17
 	domain_types = "0"
 	load_type = "0"
 	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# Crossover module config
+	# Note: Crossover has init_config set to 1 to let kernel know that the base_cfg_ext needs to
+	# be appended to the IPC payload. The Extension is needed to know the output pin indices.
+	[[module.entry]]
+	name = "XOVER"
+	uuid = "948C9AD1-806A-4131-AD6C-B2BDA9E35A9F"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	init_config = "1"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 	# pin = [dir, type, sample rate, size, container, channel-cfg]


### PR DESCRIPTION
The configuration is for now copy from IIR, name and UUID are changed. The init_config is set to 1 to let kernel know that the base_cfg_ext is passed to firmware.