### PR TITLE
Config: Add crossover component for MTL and LNL platforms

### DIFF
--- a/config/lnl.toml
+++ b/config/lnl.toml
@@ -57,7 +57,7 @@ name = "ADSPFW"
 load_offset = "0x40000"
 
 [module]
-count = 20
+count = 21
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
@@ -496,6 +496,25 @@ count = 20
 	domain_types = "0"
 	load_type = "0"
 	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# Crossover module config
+	# Note: Crossover has init_config set to 1 to let kernel know that the base_cfg_ext needs to
+	# be appended to the IPC payload. The Extension is needed to know the output pin indices.
+	[[module.entry]]
+	name = "XOVER"
+	uuid = "948C9AD1-806A-4131-AD6C-B2BDA9E35A9F"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	init_config = "1"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 	# pin = [dir, type, sample rate, size, container, channel-cfg]

--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -57,7 +57,7 @@ name = "ADSPFW"
 load_offset = "0x40000"
 
 [module]
-count = 20
+count = 21
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
@@ -496,6 +496,25 @@ count = 20
 	domain_types = "0"
 	load_type = "0"
 	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# Crossover module config
+	# Note: Crossover has init_config set to 1 to let kernel know that the base_cfg_ext needs to
+	# be appended to the IPC payload. The Extension is needed to know the output pin indices.
+	[[module.entry]]
+	name = "XOVER"
+	uuid = "948C9AD1-806A-4131-AD6C-B2BDA9E35A9F"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	init_config = "1"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 	# pin = [dir, type, sample rate, size, container, channel-cfg]


### PR DESCRIPTION
This PR adds the crossover component for MTL and LNL. The parameters are copied from TGL and TGL-H configuration of crossover.