### PR TITLE
config: lnl+mtl: fix length of ADSP.man CSE manifest

### DIFF
--- a/config/lnl.toml
+++ b/config/lnl.toml
@@ -30,7 +30,7 @@ partition_name = "ADSP"
 [[cse.entry]]
 name = "ADSP.man"
 offset = "0x5c"
-length = "0x464"
+length = "0x4b8"
 [[cse.entry]]
 name = "ADSP.met"
 offset = "0x4c0"

--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -30,7 +30,7 @@ partition_name = "ADSP"
 [[cse.entry]]
 name = "ADSP.man"
 offset = "0x5c"
-length = "0x464"
+length = "0x4b8"
 [[cse.entry]]
 name = "ADSP.met"
 offset = "0x4c0"


### PR DESCRIPTION
The ADSP.man contents is different for ACE_V1_5 layout compared to CAVS_V2_5 layout. so the ADSP.man length should be adjusted accordingly.

With this fix, sof_ri_info.py can be used to analyze LNL and MTL firmware images created with rimage.

Closes: https://github.com/thesofproject/sof/issues/8073