### PR TITLE
[RFC] rimage: Add support for multiple toml file

### DIFF
--- a/src/include/rimage/adsp_config.h
+++ b/src/include/rimage/adsp_config.h
@@ -5,5 +5,5 @@
 #include <rimage/rimage.h>
 #include <stdbool.h>
 
-int adsp_parse_config(const char *file, struct image *image);
+int adsp_parse_config(const struct adsp_conf_files *file, struct image *image);
 void adsp_free(struct adsp *adsp);

--- a/src/include/rimage/rimage.h
+++ b/src/include/rimage/rimage.h
@@ -15,6 +15,7 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 #define MAX_MODULES		32
+#define MAX_SUPPORTED_CONF_FILES	8
 
 struct adsp;
 
@@ -126,6 +127,12 @@ struct adsp {
 	struct fw_image_manifest_v1_5_sue *man_v1_5_sue;
 	struct fw_image_manifest_module *modules;
 	int exec_boot_ldr;
+};
+
+struct adsp_conf_files {
+	uint32 file_count;
+	char *file[MAX_SUPPORTED_CONF_FILES];
+	char *out_file;
 };
 
 int ri_manifest_sign_v1_5(struct image *image);

--- a/src/rimage.c
+++ b/src/rimage.c
@@ -122,8 +122,8 @@ int main(int argc, char *argv[])
 		return -EINVAL;
 	}
 
-	/* make sure we have an outfile if not verifying */
-	if ((!image.out_file && !image.verify_file)) {
+	/* We are either signing or verifying an image, not both or neither */
+	if (!(!!image.out_file ^ !!image.verify_file)) {
 		usage(argv[0]);
 		return -EINVAL;
 	}


### PR DESCRIPTION
add support for multiple toml file for rimage, prepare for split toml file
to platform related toml and algorithm related toml.

The previous RFC #176 won't work for windows system, because it uses a linux specific function,
This RFC should work both for windows and linux.