### PR TITLE
mtl: remove smart amp config in basefw

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -57,7 +57,7 @@ name = "ADSPFW"
 load_offset = "0x40000"
 
 [module]
-count = 25
+count = 24
 	[[module.entry]]
 	name = "BRNGUP"
 	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
@@ -445,27 +445,6 @@ count = 25
 
 	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 14400, 1114000, 16, 16, 0, 0, 0]
-
-	# smart amp test module config
-	[[module.entry]]
-	name = "SMATEST"
-	uuid = "167A961E-8AE4-11EA-89F1-000C29CE1635"
-	affinity_mask = "0x1"
-	instance_count = "1"
-	domain_types = "0"
-	load_type = "0"
-	init_config = "1"
-	module_type = "0xD"
-	auto_start = "0"
-	sched_caps = [1, 0x00008000]
-
-	# pin = [dir, type, sample rate, size, container, channel-cfg]
-	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
-			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
-			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
-
-	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
-	mod_cfg = [0, 0, 0, 0, 296, 5000000, 384, 384, 0, 5000, 0]
 
 	# eq iir module config
 	[[module.entry]]


### PR DESCRIPTION
Smart amp will be a loadable module.

It is only for mtl-006-stable branch. Since rimage was integrated into sof, this change will not affect main branch.