### PR TITLE
CMakeLists.txt: mention cherry-pick across repos in build error too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ message(FATAL_ERROR
 "The rimage 'main' branch has been moved to:
   https://github.com/thesofproject/sof/tree/main/tools/rimage
 Please use another branch.
+Note you can `git cherry-pick -x` commits across the different \
+sof and rimage git repositories, see example in the README.md here.
 For more see https://github.com/thesofproject/sof/issues/8178")
 endif()
 


### PR DESCRIPTION
This was meant to be part of previous commit b38fef772bf5 ("README.md: show how to git cherry-pick across sof.git and rimage.git") but I forgot it.