### PR TITLE
[stable-v2.7] config/lnl.toml: drop now invalid signed_pkg.partition_usage

### DIFF
--- a/config/lnl.toml
+++ b/config/lnl.toml
@@ -44,7 +44,6 @@ length = "0x0"  # calculated by rimage
 
 [signed_pkg]
 name = "ADSP"
-partition_usage = "0x23"
 [[signed_pkg.module]]
 name = "ADSP.met"
 


### PR DESCRIPTION
Fixes commit fbea59358d06 ("rimage: mtl: fix key slot setup based on imr type") which broke LNL compilation like this:

```
error: 1 unparsed keys left in 'signed_pkg'
error: key 'signed_pkg' parsing error
```

Of course LNL is never going to be released on this stable-v2.7 branch but this one-line fix is just the smallest and simplest fix to keep everything building and green. It also keeps everything simple and consistent.

This commit does not change the final image (compared to before rimage commit fbea59358d06) because the default value is now 0x20 + IMR type.

Fixes are normally submitted to the main branch first and then cherry picked to stable branches. However fbea59358d06 has been made in stable-v2.7 first so make this change also in stable-v2.7 first for consistency.