### PR TITLE
loadable module: define a new bit in fw_image_flags

### DIFF
--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -55,6 +55,7 @@ base_offset = "0x2000"
 [fw_desc.header]
 name = "ADSPFW"
 load_offset = "0x40000"
+fw_image_flags = "0x12" # BASE_FW (bit 1) + CONTEXT_IS_NOT_SAVED (bit 4)
 
 [module]
 count = 18

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1463,7 +1463,6 @@ int man_write_fw_ace_v1_5(struct image *image)
 	m->desc.header.build_version = image->fw_ver_build;
 
 	m->desc.header.feature_mask = 0x2; // -> should be feature mask - to fix
-	m->desc.header.fw_image_flags = 0x2; // -> should be feature mask - to fix
 	m->desc.header.fw_compat = 0x100000; // -> PUT PROPER STRUCT
 
 	/* create each module */


### PR DESCRIPTION
The bit 4 is set to force driver reload library on d3 exit.

It is a prototype for validation with mtl-006 branch so I use hard core.  We need to add a new feature that toml can decode macro definition like
fw_image_flag = BASE_FW | RELOAD_LIBRARY

Kernel PR https://github.com/thesofproject/linux/pull/4669 depends on this rimage update.